### PR TITLE
fix: 使用 box-shadow 实现完美贴合的绿色边框

### DIFF
--- a/Docs/index.html
+++ b/Docs/index.html
@@ -293,7 +293,7 @@
                     <!-- 主预览卡片 -->
                     <div class="relative rounded-2xl overflow-hidden shadow-2xl shadow-primary-500/20">
                         <div class="w-full h-[60vh] min-h-[400px] max-h-[700px] relative overflow-hidden">
-                            <img src="./app-screenshot-real.png" alt="WallHaven App Screenshot" class="w-full h-full object-cover" style="outline: 2px solid rgba(34, 197, 94, 0.7); outline-offset: -2px;" onerror="this.src='./app-preview.png'">
+                            <img src="./app-screenshot-real.png" alt="WallHaven App Screenshot" class="w-full h-full object-cover rounded-lg shadow-[0_0_0_2px_rgba(34,197,94,0.8)]" onerror="this.src='./app-preview.png'">
                         </div>
                     </div>
                 </div>


### PR DESCRIPTION
使用 box-shadow 替代 outline，实现更精准贴合的绿色边框