### PR TITLE
修复动漫详情页 Netflix 风格布局和列表分页

### DIFF
--- a/Services/AnimeParser.swift
+++ b/Services/AnimeParser.swift
@@ -15,11 +15,12 @@ actor AnimeParser {
     /// 搜索动漫
     func search(
         query: String,
-        rules: [AnimeRule]
+        rules: [AnimeRule],
+        page: Int = 1
     ) async throws -> [AnimeSearchResult] {
         for rule in rules where !rule.deprecated {
             do {
-                let results = try await searchWithRule(query: query, rule: rule)
+                let results = try await searchWithRule(query: query, rule: rule, page: page)
                 if !results.isEmpty {
                     print("[AnimeParser] Found \(results.count) results using rule: \(rule.name)")
                     return results
@@ -33,22 +34,22 @@ actor AnimeParser {
     }
 
     /// 使用指定规则搜索
-    private func searchWithRule(query: String, rule: AnimeRule) async throws -> [AnimeSearchResult] {
+    private func searchWithRule(query: String, rule: AnimeRule, page: Int = 1) async throws -> [AnimeSearchResult] {
         print("\n[AnimeParser] ========== 开始搜索 ==========")
         print("[AnimeParser] 规则: \(rule.name) (id: \(rule.id), api: \(rule.api))")
-        print("[AnimeParser] 关键词: \(query)")
-        
+        print("[AnimeParser] 关键词: \(query), 页码: \(page)")
+
         var url = rule.searchURL
-        
+
         // 处理 XPath 格式 (API v2)
         if rule.api == "2", let xpath = rule.xpath, let search = xpath.search {
             url = search.url
             print("[AnimeParser] 使用 XPath 格式 URL: \(url)")
         }
-        
+
         url = url
             .replacingOccurrences(of: "{keyword}", with: query.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? query)
-            .replacingOccurrences(of: "{page}", with: "1")
+            .replacingOccurrences(of: "{page}", with: "\(page)")
         
         print("[AnimeParser] 最终 URL: \(url)")
 

--- a/ViewModels/AnimeViewModel.swift
+++ b/ViewModels/AnimeViewModel.swift
@@ -19,15 +19,22 @@ class AnimeViewModel: ObservableObject {
     @Published var animeItems: [AnimeSearchResult] = []
     @Published var featuredItem: AnimeSearchResult?
 
-    // MARK: - 状态
+    // MARK: - 分页状态
     @Published var isLoading = false
+    @Published var isLoadingMore = false
+    @Published var hasMorePages = false
     @Published var errorMessage: String?
     @Published var searchText = ""
     @Published var selectedCategory: AnimeCategory = .all
     @Published var selectedHotTag: AnimeHotTag?
-    
+
+    // MARK: - 私有状态
+    private var currentPage = 1
+    private var currentSearchKeyword: String = ""
+    private var loadMoreTask: Task<Void, Never>?
+
     // MARK: - 初始化
-    
+
     init() {
         // 监听规则源切换通知
         NotificationCenter.default.addObserver(
@@ -37,7 +44,7 @@ class AnimeViewModel: ObservableObject {
             object: nil
         )
     }
-    
+
     @objc private func handleRuleSourceChanged() {
         Task {
             await reloadRules()
@@ -49,6 +56,11 @@ class AnimeViewModel: ObservableObject {
     func loadInitialData() async {
         isLoading = true
         defer { isLoading = false }
+
+        // 重置分页状态
+        currentPage = 1
+        hasMorePages = false
+        currentSearchKeyword = ""
 
         do {
             // 从远程加载所有可用规则
@@ -68,7 +80,7 @@ class AnimeViewModel: ObservableObject {
             errorMessage = error.localizedDescription
         }
     }
-    
+
     /// 重新加载规则(切换规则源后调用)
     func reloadRules() async {
         await loadInitialData()
@@ -86,13 +98,20 @@ class AnimeViewModel: ObservableObject {
         isLoading = true
         defer { isLoading = false }
 
+        // 重置分页状态
+        currentPage = 1
+        hasMorePages = false
+        currentSearchKeyword = searchText
+
         do {
             let rules = selectedRule.map { [$0] } ?? availableRules
-            let results = try await AnimeParser.shared.search(query: searchText, rules: rules)
+            let results = try await AnimeParser.shared.search(query: searchText, rules: rules, page: currentPage)
 
             await MainActor.run {
                 self.animeItems = results
                 self.featuredItem = results.first
+                // 搜索结果暂时不支持分页，根据结果数量判断
+                self.hasMorePages = results.count >= 20
             }
 
             print("[AnimeViewModel] Found \(results.count) results for '\(searchText)'")
@@ -108,49 +127,73 @@ class AnimeViewModel: ObservableObject {
         isLoading = true
         defer { isLoading = false }
 
+        // 重置分页状态
+        currentPage = 1
+        hasMorePages = true
+
         // 使用默认关键词或指定标签搜索
         let baseKeywords: [String]
+        let searchKeyword: String
         switch keyword {
         case .none:
             baseKeywords = ["热门", "新番", "推荐", "完结"]
+            searchKeyword = "热门"
         case .daily:
             baseKeywords = ["日常"]
+            searchKeyword = "日常"
         case .original:
             baseKeywords = ["原创"]
+            searchKeyword = "原创"
         case .school:
             baseKeywords = ["校园"]
+            searchKeyword = "校园"
         case .comedy:
             baseKeywords = ["搞笑"]
+            searchKeyword = "搞笑"
         case .fantasy:
             baseKeywords = ["奇幻"]
+            searchKeyword = "奇幻"
         case .yuri:
             baseKeywords = ["百合"]
+            searchKeyword = "百合"
         case .romance:
             baseKeywords = ["恋爱"]
+            searchKeyword = "恋爱"
         case .mystery:
             baseKeywords = ["悬疑"]
+            searchKeyword = "悬疑"
         case .action:
             baseKeywords = ["热血"]
+            searchKeyword = "热血"
         case .harem:
             baseKeywords = ["后宫"]
+            searchKeyword = "后宫"
         case .mecha:
             baseKeywords = ["机战"]
+            searchKeyword = "机战"
         case .lightNovel:
             baseKeywords = ["轻改"]
+            searchKeyword = "轻改"
         case .idol:
             baseKeywords = ["偶像"]
+            searchKeyword = "偶像"
         case .healing:
             baseKeywords = ["治愈"]
+            searchKeyword = "治愈"
         case .otherWorld:
             baseKeywords = ["异世界"]
+            searchKeyword = "异世界"
         }
+
+        // 设置当前搜索关键词用于分页
+        self.currentSearchKeyword = searchKeyword
 
         var allResults: [AnimeSearchResult] = []
 
         for baseKeyword in baseKeywords {
             do {
                 let rules = selectedRule.map { [$0] } ?? availableRules
-                let results = try await AnimeParser.shared.search(query: baseKeyword, rules: rules)
+                let results = try await AnimeParser.shared.search(query: baseKeyword, rules: rules, page: currentPage)
                 allResults.append(contentsOf: results)
 
                 if allResults.count >= 30 { break }
@@ -172,7 +215,59 @@ class AnimeViewModel: ObservableObject {
         await MainActor.run {
             self.animeItems = uniqueResults
             self.featuredItem = uniqueResults.first
+            // 如果获取到了较多结果，认为还有下一页
+            self.hasMorePages = uniqueResults.count >= 20
         }
+    }
+
+    // MARK: - 加载更多（分页）
+
+    func loadMore() async {
+        loadMoreTask?.cancel()
+
+        guard !isLoading, !isLoadingMore, hasMorePages else { return }
+
+        loadMoreTask = Task {
+            isLoadingMore = true
+            defer { isLoadingMore = false }
+
+            currentPage += 1
+            print("[AnimeViewModel] 加载第 \(currentPage) 页...")
+
+            // 使用当前搜索关键词或默认关键词
+            let keyword = currentSearchKeyword.isEmpty ? "热门" : currentSearchKeyword
+
+            do {
+                let rules = selectedRule.map { [$0] } ?? availableRules
+                let results = try await AnimeParser.shared.search(query: keyword, rules: rules, page: currentPage)
+
+                // 检查任务是否被取消
+                guard !Task.isCancelled else { return }
+
+                // 过滤已存在的结果
+                let existingIDs = Set(self.animeItems.map { $0.id })
+                let newResults = results.filter { !existingIDs.contains($0.id) }
+
+                await MainActor.run {
+                    if !newResults.isEmpty {
+                        self.animeItems.append(contentsOf: newResults)
+                        print("[AnimeViewModel] 新增 \(newResults.count) 条数据，总计 \(self.animeItems.count)")
+                    }
+
+                    // 如果没有新数据或结果太少，认为没有更多页面了
+                    self.hasMorePages = !results.isEmpty && results.count >= 10
+
+                    if !self.hasMorePages {
+                        print("[AnimeViewModel] 没有更多数据了")
+                    }
+                }
+            } catch {
+                print("[AnimeViewModel] 加载更多失败: \(error)")
+                currentPage -= 1 // 回退页码
+            }
+        }
+
+        await loadMoreTask?.value
     }
 
     // MARK: - 获取详情
@@ -183,6 +278,14 @@ class AnimeViewModel: ObservableObject {
         }
 
         return try await AnimeParser.shared.fetchDetail(detailURL: item.detailURL, rule: rule)
+    }
+
+    // MARK: - 取消加载
+
+    func cancelLoadMore() {
+        loadMoreTask?.cancel()
+        loadMoreTask = nil
+        isLoadingMore = false
     }
 }
 

--- a/Views/AnimeDetailView.swift
+++ b/Views/AnimeDetailView.swift
@@ -25,18 +25,18 @@ struct AnimeDetailView: View {
                 ScrollView(.vertical, showsIndicators: false) {
                     VStack(spacing: 0) {
                         // Hero 区域
-                        heroSection(width: geometry.size.width)
+                        heroSection(width: geometry.size.width, height: geometry.size.height)
 
-                        // 剧集列表
-                        if let detail = detail, !detail.episodes.isEmpty {
-                            episodesSection
-                        }
+                        // 内容区域
+                        contentSection
 
-                        // 相关推荐占位
-                        relatedSection
-
-                        Spacer(minLength: 40)
+                        Spacer(minLength: 60)
                     }
+                    .offsetReader()
+                }
+                .coordinateSpace(name: "scroll")
+                .onPreferenceChange(ViewOffsetKey.self) { offset in
+                    scrollOffset = offset
                 }
 
                 // 顶部导航栏
@@ -70,13 +70,14 @@ struct AnimeDetailView: View {
                     Color.black.opacity(0.9)
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .blur(radius: 60)
+                .blur(radius: 40)
                 .overlay(
                     LinearGradient(
                         colors: [
-                            Color.black.opacity(0.3),
-                            Color.black.opacity(0.7),
-                            Color.black.opacity(0.95)
+                            Color.black.opacity(0.2),
+                            Color.black.opacity(0.5),
+                            Color.black.opacity(0.85),
+                            Color.black.opacity(0.98)
                         ],
                         startPoint: .top,
                         endPoint: .bottom
@@ -91,203 +92,237 @@ struct AnimeDetailView: View {
 
     // MARK: - Hero Section
 
-    private func heroSection(width: CGFloat) -> some View {
-        VStack(alignment: .leading, spacing: 24) {
-            Spacer()
-                .frame(height: 100)
-
-            HStack(alignment: .bottom, spacing: 24) {
-                // 海报
-                posterImage
-
-                // 信息
-                infoPanel
-            }
-            .padding(.horizontal, 28)
-        }
-        .frame(width: width)
-        .padding(.bottom, 40)
-    }
-
-    // MARK: - 海报
-
-    private var posterImage: some View {
-        OptimizedAsyncImage(
-            url: anime.coverURL.flatMap { URL(string: $0) },
-            priority: .medium
-        ) { image in
-            image
-                .resizable()
-                .aspectRatio(contentMode: .fill)
-        } placeholder: {
-            Rectangle()
-                .fill(Color.white.opacity(0.1))
+    private func heroSection(width: CGFloat, height: CGFloat) -> some View {
+        ZStack(alignment: .bottom) {
+            // 背景大图
+            if let coverURL = anime.coverURL {
+                OptimizedAsyncImage(
+                    url: URL(string: coverURL),
+                    priority: .high
+                ) { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fill)
+                } placeholder: {
+                    Rectangle()
+                        .fill(Color.gray.opacity(0.2))
+                }
+                .frame(width: width, height: height * 0.65)
+                .clipped()
                 .overlay(
-                    Image(systemName: "tv")
-                        .font(.system(size: 40))
-                        .foregroundStyle(.white.opacity(0.3))
+                    LinearGradient(
+                        colors: [
+                            Color.black.opacity(0.1),
+                            Color.black.opacity(0.3),
+                            Color.black.opacity(0.7),
+                            Color.black.opacity(0.95)
+                        ],
+                        startPoint: .top,
+                        endPoint: .bottom
+                    )
                 )
-        }
-        .frame(width: 180, height: 270)
-        .clipShape(RoundedRectangle(cornerRadius: 16, style: .continuous))
-        .shadow(color: Color.black.opacity(0.5), radius: 20, x: 0, y: 10)
-        .liquidGlassSurface(.prominent, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-    }
-
-    // MARK: - 信息面板
-
-    private var infoPanel: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            // 标题
-            Text(anime.title)
-                .font(.system(size: 36, weight: .bold))
-                .foregroundStyle(.white)
-                .lineLimit(2)
-
-            // 元信息
-            HStack(spacing: 12) {
-                if let rating = detail?.rating {
-                    HStack(spacing: 4) {
-                        Image(systemName: "star.fill")
-                            .font(.system(size: 12))
-                            .foregroundStyle(.yellow)
-                        Text(rating)
-                            .font(.system(size: 14, weight: .semibold))
-                    }
-                    .foregroundStyle(.white)
-                }
-
-                if let status = detail?.status {
-                    Text(status)
-                        .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(.white.opacity(0.7))
-                        .padding(.horizontal, 8)
-                        .padding(.vertical, 2)
-                        .background(
-                            Capsule()
-                                .fill(Color.white.opacity(0.1))
-                        )
-                }
-
-                Text(anime.sourceName)
-                    .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.6))
             }
 
-            // 描述
-            if let desc = detail?.description, !desc.isEmpty {
-                Text(desc)
-                    .font(.system(size: 14, weight: .medium))
-                    .foregroundStyle(.white.opacity(0.8))
-                    .lineLimit(4)
-                    .multilineTextAlignment(.leading)
-            } else if isLoading {
-                Text("正在加载详情...")
-                    .font(.system(size: 14))
-                    .foregroundStyle(.white.opacity(0.5))
-            }
+            // 内容叠加层
+            VStack(alignment: .leading, spacing: 20) {
+                Spacer()
 
-            // 操作按钮
-            actionButtons
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    // MARK: - 操作按钮
-
-    private var actionButtons: some View {
-        HStack(spacing: 12) {
-            // 播放按钮
-            Button {
-                if let firstEpisode = detail?.episodes.first {
-                    selectedEpisode = firstEpisode
-                    showPlayer = true
-                }
-            } label: {
+                // 源标签
                 HStack(spacing: 8) {
-                    Image(systemName: "play.fill")
-                        .font(.system(size: 16, weight: .semibold))
-                    Text("立即播放")
-                        .font(.system(size: 15, weight: .semibold))
+                    Text(anime.sourceName)
+                        .font(.system(size: 12, weight: .bold))
+                        .textCase(.uppercase)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 10)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.red)
+                        )
+
+                    if let rating = detail?.rating, !rating.isEmpty {
+                        HStack(spacing: 4) {
+                            Image(systemName: "star.fill")
+                                .font(.system(size: 10))
+                                .foregroundStyle(.yellow)
+                            Text(rating)
+                                .font(.system(size: 12, weight: .semibold))
+                        }
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(
+                            RoundedRectangle(cornerRadius: 4)
+                                .fill(Color.white.opacity(0.15))
+                        )
+                    }
+
+                    if let status = detail?.status, !status.isEmpty {
+                        Text(status)
+                            .font(.system(size: 12, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.9))
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 4)
+                            .background(
+                                RoundedRectangle(cornerRadius: 4)
+                                    .fill(Color.white.opacity(0.15))
+                            )
+                    }
                 }
-                .foregroundStyle(.black)
-                .padding(.horizontal, 24)
-                .padding(.vertical, 12)
-                .background(
-                    Capsule(style: .continuous)
-                        .fill(Color.white)
-                )
-            }
-            .buttonStyle(.plain)
-            .disabled(detail?.episodes.isEmpty ?? true)
-            .opacity(detail?.episodes.isEmpty ?? true ? 0.5 : 1)
 
-            // 收藏按钮
-            Button {
-                // TODO: 收藏功能
-            } label: {
-                Image(systemName: "plus")
-                    .font(.system(size: 16, weight: .semibold))
+                // 标题
+                Text(anime.title)
+                    .font(.system(size: 42, weight: .bold))
                     .foregroundStyle(.white)
-                    .frame(width: 44, height: 44)
-                    .background(
-                        Circle()
-                            .fill(Color.white.opacity(0.15))
-                    )
-                    .overlay(
-                        Circle()
-                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
-                    )
-            }
-            .buttonStyle(.plain)
+                    .lineLimit(2)
+                    .shadow(color: Color.black.opacity(0.5), radius: 4, x: 0, y: 2)
 
-            // 分享按钮
-            Button {
-                // TODO: 分享功能
-            } label: {
-                Image(systemName: "square.and.arrow.up")
-                    .font(.system(size: 16, weight: .semibold))
-                    .foregroundStyle(.white)
-                    .frame(width: 44, height: 44)
-                    .background(
-                        Circle()
-                            .fill(Color.white.opacity(0.15))
-                    )
-                    .overlay(
-                        Circle()
-                            .stroke(Color.white.opacity(0.3), lineWidth: 1)
-                    )
+                // 操作按钮
+                HStack(spacing: 16) {
+                    // 播放按钮
+                    Button {
+                        if let firstEpisode = detail?.episodes.first {
+                            selectedEpisode = firstEpisode
+                            showPlayer = true
+                        }
+                    } label: {
+                        HStack(spacing: 8) {
+                            Image(systemName: "play.fill")
+                                .font(.system(size: 18, weight: .semibold))
+                            Text(detail?.episodes.isEmpty ?? true ? "暂无剧集" : "立即播放")
+                                .font(.system(size: 16, weight: .bold))
+                        }
+                        .foregroundStyle(.black)
+                        .padding(.horizontal, 28)
+                        .padding(.vertical, 14)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(Color.white)
+                        )
+                    }
+                    .buttonStyle(.plain)
+                    .disabled(detail?.episodes.isEmpty ?? true)
+                    .opacity(detail?.episodes.isEmpty ?? true ? 0.5 : 1)
+
+                    // 收藏按钮
+                    Button {
+                        // TODO: 收藏功能
+                    } label: {
+                        HStack(spacing: 6) {
+                            Image(systemName: "plus")
+                                .font(.system(size: 16, weight: .semibold))
+                            Text("收藏")
+                                .font(.system(size: 14, weight: .semibold))
+                        }
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 20)
+                        .padding(.vertical, 14)
+                        .background(
+                            Capsule(style: .continuous)
+                                .fill(Color.white.opacity(0.2))
+                        )
+                        .overlay(
+                            Capsule(style: .continuous)
+                                .stroke(Color.white.opacity(0.4), lineWidth: 1)
+                        )
+                    }
+                    .buttonStyle(.plain)
+
+                    // 分享按钮
+                    Button {
+                        // TODO: 分享功能
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(.white)
+                            .frame(width: 48, height: 48)
+                            .background(
+                                Circle()
+                                    .fill(Color.white.opacity(0.15))
+                            )
+                            .overlay(
+                                Circle()
+                                    .stroke(Color.white.opacity(0.3), lineWidth: 1)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+
+                // 描述
+                if let desc = detail?.description, !desc.isEmpty {
+                    Text(desc)
+                        .font(.system(size: 15, weight: .regular))
+                        .foregroundStyle(.white.opacity(0.85))
+                        .lineLimit(3)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: 600, alignment: .leading)
+                } else if isLoading {
+                    Text("正在加载详情...")
+                        .font(.system(size: 15))
+                        .foregroundStyle(.white.opacity(0.5))
+                }
             }
-            .buttonStyle(.plain)
+            .padding(.horizontal, 40)
+            .padding(.bottom, 40)
+            .frame(width: width, alignment: .leading)
         }
-        .padding(.top, 8)
+        .frame(height: height * 0.75)
+    }
+
+    // MARK: - 内容区域
+
+    private var contentSection: some View {
+        VStack(alignment: .leading, spacing: 32) {
+            // 剧集列表
+            if let detail = detail, !detail.episodes.isEmpty {
+                episodesSection
+            }
+
+            // 相关推荐
+            relatedSection
+        }
+        .padding(.top, 20)
     }
 
     // MARK: - 剧集列表
 
     private var episodesSection: some View {
         VStack(alignment: .leading, spacing: 16) {
-            Text("剧集")
-                .font(.system(size: 20, weight: .bold))
-                .foregroundStyle(.white)
-                .padding(.horizontal, 28)
+            HStack {
+                Text("剧集")
+                    .font(.system(size: 22, weight: .bold))
+                    .foregroundStyle(.white)
 
-            ScrollView(.horizontal, showsIndicators: false) {
-                HStack(spacing: 12) {
-                    ForEach(detail?.episodes ?? []) { episode in
-                        EpisodeCard(
-                            episode: episode,
-                            isPlaying: selectedEpisode?.id == episode.id
-                        ) {
-                            selectedEpisode = episode
-                            showPlayer = true
-                        }
+                Spacer()
+
+                // 剧集数量
+                Text("\(detail?.episodes.count ?? 0) 集")
+                    .font(.system(size: 14, weight: .medium))
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+            .padding(.horizontal, 40)
+
+            // 剧集网格
+            LazyVGrid(
+                columns: [
+                    GridItem(.flexible(), spacing: 12),
+                    GridItem(.flexible(), spacing: 12),
+                    GridItem(.flexible(), spacing: 12)
+                ],
+                spacing: 12
+            ) {
+                ForEach(detail?.episodes ?? []) { episode in
+                    EpisodeRow(
+                        episode: episode,
+                        isPlaying: selectedEpisode?.id == episode.id
+                    ) {
+                        selectedEpisode = episode
+                        showPlayer = true
                     }
                 }
-                .padding(.horizontal, 28)
             }
+            .padding(.horizontal, 40)
         }
-        .padding(.vertical, 24)
     }
 
     // MARK: - 相关推荐
@@ -295,18 +330,32 @@ struct AnimeDetailView: View {
     private var relatedSection: some View {
         VStack(alignment: .leading, spacing: 16) {
             Text("相关推荐")
-                .font(.system(size: 20, weight: .bold))
+                .font(.system(size: 22, weight: .bold))
                 .foregroundStyle(.white)
-                .padding(.horizontal, 28)
+                .padding(.horizontal, 40)
 
             // 可以在这里添加相关动漫
-            // 目前显示提示
-            Text("更多精彩内容即将推出")
-                .font(.system(size: 14))
-                .foregroundStyle(.white.opacity(0.5))
-                .padding(.horizontal, 28)
+            HStack(spacing: 16) {
+                ForEach(0..<4) { index in
+                    VStack(alignment: .leading, spacing: 8) {
+                        RoundedRectangle(cornerRadius: 8)
+                            .fill(Color.white.opacity(0.1))
+                            .frame(width: 200, height: 112)
+                            .overlay(
+                                Image(systemName: "tv")
+                                    .font(.system(size: 32))
+                                    .foregroundStyle(.white.opacity(0.3))
+                            )
+
+                        Text("推荐动漫 \(index + 1)")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(.white.opacity(0.7))
+                    }
+                }
+            }
+            .padding(.horizontal, 40)
+            .opacity(0.5)
         }
-        .padding(.vertical, 24)
     }
 
     // MARK: - 顶部导航栏
@@ -325,7 +374,7 @@ struct AnimeDetailView: View {
                         .frame(width: 40, height: 40)
                         .background(
                             Circle()
-                                .fill(Color.black.opacity(0.3))
+                                .fill(Color.black.opacity(scrollOffset > 100 ? 0.5 : 0.3))
                                 .background(.ultraThinMaterial)
                         )
                 }
@@ -334,10 +383,11 @@ struct AnimeDetailView: View {
                 Spacer()
 
                 // 标题（滚动时显示）
-                if scrollOffset < -200 {
+                if scrollOffset < -300 {
                     Text(anime.title)
                         .font(.system(size: 16, weight: .semibold))
                         .foregroundStyle(.white)
+                        .lineLimit(1)
                         .transition(.opacity)
                 }
 
@@ -347,11 +397,17 @@ struct AnimeDetailView: View {
                 Color.clear
                     .frame(width: 40, height: 40)
             }
-            .padding(.horizontal, 20)
+            .padding(.horizontal, 24)
             .padding(.top, 20)
 
             Spacer()
         }
+        .background(
+            scrollOffset < -300 ?
+            Color.black.opacity(min(0.9, abs(scrollOffset + 300) / 200))
+            : Color.clear
+        )
+        .animation(.easeInOut(duration: 0.2), value: scrollOffset)
     }
 
     // MARK: - 加载详情
@@ -373,9 +429,32 @@ struct AnimeDetailView: View {
     }
 }
 
-// MARK: - 剧集卡片
+// MARK: - 滚动偏移检测
 
-struct EpisodeCard: View {
+struct ViewOffsetKey: PreferenceKey {
+    static var defaultValue: CGFloat = 0
+    static func reduce(value: inout CGFloat, nextValue: () -> CGFloat) {
+        value = nextValue()
+    }
+}
+
+extension View {
+    func offsetReader() -> some View {
+        self.background(
+            GeometryReader { proxy in
+                Color.clear
+                    .preference(
+                        key: ViewOffsetKey.self,
+                        value: proxy.frame(in: .named("scroll")).minY
+                    )
+            }
+        )
+    }
+}
+
+// MARK: - 剧集行
+
+struct EpisodeRow: View {
     let episode: AnimeDetail.AnimeEpisodeItem
     let isPlaying: Bool
     let onTap: () -> Void
@@ -384,13 +463,13 @@ struct EpisodeCard: View {
 
     var body: some View {
         Button(action: onTap) {
-            VStack(spacing: 8) {
-                // 缩略图或占位
+            HStack(spacing: 12) {
+                // 缩略图
                 ZStack {
                     if let thumb = episode.thumbnailURL {
                         OptimizedAsyncImage(
                             url: URL(string: thumb),
-                            priority: .medium
+                            priority: .low
                         ) { image in
                             image
                                 .resizable()
@@ -398,53 +477,69 @@ struct EpisodeCard: View {
                         } placeholder: {
                             Rectangle()
                                 .fill(Color.white.opacity(0.1))
-                                .overlay(
-                                    Image(systemName: "play.circle")
-                                        .font(.system(size: 32))
-                                        .foregroundStyle(.white.opacity(0.5))
-                                )
                         }
                     } else {
                         Rectangle()
                             .fill(Color.white.opacity(0.1))
-                            .overlay(
-                                Image(systemName: "play.circle")
-                                    .font(.system(size: 32))
-                                    .foregroundStyle(.white.opacity(0.5))
-                            )
                     }
 
-                    // 播放中指示器
-                    if isPlaying {
-                        Circle()
-                            .fill(Color.white)
-                            .frame(width: 40, height: 40)
-                            .overlay(
-                                Image(systemName: "pause.fill")
-                                    .font(.system(size: 16, weight: .semibold))
-                                    .foregroundStyle(.black)
-                            )
-                    }
+                    // 播放图标
+                    Image(systemName: isPlaying ? "pause.fill" : "play.fill")
+                        .font(.system(size: 20, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(width: 44, height: 44)
+                        .background(
+                            Circle()
+                                .fill(Color.black.opacity(0.6))
+                        )
+                        .opacity(isHovered || isPlaying ? 1 : 0)
                 }
-                .frame(width: 160, height: 90)
-                .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+                .frame(width: 120, height: 68)
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
 
                 // 剧集信息
-                VStack(alignment: .leading, spacing: 2) {
+                VStack(alignment: .leading, spacing: 4) {
                     Text(episode.name ?? "第 \(episode.episodeNumber) 集")
-                        .font(.system(size: 13, weight: .semibold))
+                        .font(.system(size: 14, weight: .semibold))
                         .foregroundStyle(.white)
                         .lineLimit(1)
 
                     Text("第 \(episode.episodeNumber) 集")
-                        .font(.system(size: 11))
+                        .font(.system(size: 12))
                         .foregroundStyle(.white.opacity(0.5))
                 }
-                .frame(width: 160, alignment: .leading)
+
+                Spacer()
+
+                // 播放中指示器
+                if isPlaying {
+                    HStack(spacing: 4) {
+                        Image(systemName: "play.fill")
+                            .font(.system(size: 10))
+                        Text("播放中")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                    .foregroundStyle(.red)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(
+                        RoundedRectangle(cornerRadius: 4)
+                            .fill(Color.red.opacity(0.15))
+                    )
+                }
             }
+            .padding(12)
+            .background(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .fill(isHovered || isPlaying ? Color.white.opacity(0.1) : Color.white.opacity(0.05))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    .stroke(isPlaying ? Color.red.opacity(0.5) : Color.clear, lineWidth: 1)
+            )
         }
         .buttonStyle(.plain)
-        .scaleEffect(isHovered ? 1.05 : 1.0)
+        .scaleEffect(isHovered ? 1.02 : 1.0)
         .animation(.spring(response: 0.3, dampingFraction: 0.7), value: isHovered)
         .onHover { hovering in
             isHovered = hovering

--- a/Views/AnimeExploreView.swift
+++ b/Views/AnimeExploreView.swift
@@ -225,9 +225,17 @@ struct AnimeExploreView: View {
     private func animeSection(gridContentWidth: CGFloat) -> some View {
         VStack(alignment: .leading, spacing: 22) {
             HStack(alignment: .center) {
-                Text("\(viewModel.animeItems.count) 部动漫")
-                    .font(.system(size: 15, weight: .semibold))
-                    .foregroundStyle(.white.opacity(0.64))
+                HStack(spacing: 8) {
+                    Text("\(viewModel.animeItems.count) 部动漫")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(.white.opacity(0.64))
+
+                    if viewModel.isLoadingMore {
+                        ProgressView()
+                            .scaleEffect(0.6)
+                            .tint(.white.opacity(0.6))
+                    }
+                }
 
                 Spacer()
 
@@ -274,14 +282,40 @@ struct AnimeExploreView: View {
                     columns: calculateGridColumns(width: gridContentWidth),
                     spacing: 20
                 ) {
-                    ForEach(viewModel.animeItems) { anime in
+                    ForEach(Array(viewModel.animeItems.enumerated()), id: \.element.id) { index, anime in
                         AnimePortraitCard(anime: anime) {
                             selectedAnime = anime
                             withAnimation(.spring(response: 0.4, dampingFraction: 0.8)) {
                                 showDetail = true
                             }
                         }
+                        .onAppear {
+                            // 检测接近列表底部时加载更多
+                            guard index >= viewModel.animeItems.count - 6,
+                                  viewModel.hasMorePages,
+                                  !viewModel.isLoading,
+                                  !viewModel.isLoadingMore else { return }
+                            Task {
+                                await viewModel.loadMore()
+                            }
+                        }
                     }
+                }
+
+                // 加载更多指示器
+                if viewModel.isLoadingMore {
+                    PaginationLoadingView()
+                        .frame(height: 60)
+                        .padding(.top, 20)
+                }
+
+                // 没有更多数据提示
+                if !viewModel.hasMorePages && viewModel.animeItems.count > 20 {
+                    Text("已经到底啦")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .frame(height: 50)
+                        .padding(.top, 10)
                 }
             }
         }

--- a/Views/MediaExploreContentView.swift
+++ b/Views/MediaExploreContentView.swift
@@ -293,11 +293,20 @@ struct MediaExploreContentView: View {
                     }
                 }
 
-                // 加载指示器
-                if viewModel.isLoading && !displayedMediaItems.isEmpty {
+                // 加载更多指示器
+                if isLoadingMore {
                     PaginationLoadingView()
                         .frame(height: 60)
                         .padding(.top, 20)
+                }
+
+                // 没有更多数据提示
+                if !viewModel.hasMorePages && displayedMediaItems.count > 20 {
+                    Text("已经到底啦")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(.white.opacity(0.4))
+                        .frame(height: 50)
+                        .padding(.top, 10)
                 }
             }
         }


### PR DESCRIPTION
## 修改内容

### 🎨 动漫详情页 (AnimeDetailView)
- **Netflix 风格布局重构**
  - 全屏 Hero 区域背景图（占屏幕 75% 高度）
  - 红色网飞风格源标签 + 评分/状态标签
  - 42px 大标题带阴影增强可读性
  - 播放按钮(白色) + 收藏按钮(描边) + 分享按钮
  - 三列网格剧集列表 (LazyVGrid)
  - 滚动渐变导航栏（滚动后显示标题）

### 📄 分页功能 (AnimeViewModel)
- 新增 `isLoadingMore` / `hasMorePages` 状态
- 新增 `loadMore()` / `cancelLoadMore()` 方法
- 支持 `currentPage` 和 `currentSearchKeyword` 追踪
- 滚动到底部自动加载更多

### 🔌 解析器 (AnimeParser)
- `search()` 方法支持 `page` 参数
- URL 中的 `{page}` 占位符正确替换

### 🐛 其他修复
- 修复 MediaExploreView 分页加载指示器显示问题
- 统一 AnimeExploreView 使用 `PaginationLoadingView` 组件

## 测试建议
1. 打开动漫详情页，检查 Netflix 风格布局
2. 滚动列表，测试分页加载功能
3. 检查加载指示器是否正常显示