### PR TITLE
Fix shared video wallpaper transitions

### DIFF
--- a/Services/LocalWallpaperApplyService.swift
+++ b/Services/LocalWallpaperApplyService.swift
@@ -20,8 +20,8 @@ enum LocalWallpaperApplyService {
     }
 
     struct Options {
-        /// 调度切换淡入；手动默认 false
-        var animatedTransition: Bool = false
+        /// 所有用户可见的壁纸切换默认启用首帧预热过渡；恢复/回滚路径可显式关闭。
+        var animatedTransition: Bool = true
         /// 播完即换且未开 web/scene 定时：跳过无播放完成事件的类型
         var requirePlaybackEndSupport: Bool = false
         var muted: Bool = true
@@ -99,7 +99,7 @@ enum LocalWallpaperApplyService {
         let contentRoot = WorkshopService.resolveWallpaperEngineProjectRoot(startingAt: localURL)
         ensurePresetHTMLGenerated(at: contentRoot)
 
-        let isRealtime = UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled")
+        let isRealtime = UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true
         let contentType = determineWorkshopContentType(at: contentRoot)
         let allowNonVideoInOnEnd = !options.requirePlaybackEndSupport || screens.contains { hasWebSceneTimer(for: $0) }
 
@@ -331,7 +331,7 @@ enum LocalWallpaperApplyService {
         if WallpaperEngineXBridge.resolvedCLIExecutableURL() == nil {
             throw ApplyError.failed("wallpaper-wgpu 渲染器未找到")
         }
-        let isRealtime = UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled")
+        let isRealtime = UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true
         // user properties 仅 scene 实时有意义；web 传 nil
         let userProps = (scheduleSceneCompanionBake && isRealtime)
             ? SceneWallpaperPropertiesService.propertiesOverrideJSON(for: path)

--- a/Services/StaticImageWallpaperOverlayManager.swift
+++ b/Services/StaticImageWallpaperOverlayManager.swift
@@ -229,6 +229,22 @@ final class StaticImageWallpaperOverlayManager {
         return imageByScreen[screenID] ?? imageByScreenFingerprint[fingerprint]
     }
 
+    func hasActiveWallpaper(on screens: [NSScreen]) -> Bool {
+        screens.contains { screen in
+            imageWindows[screen.wallpaperScreenIdentifier] != nil
+        }
+    }
+
+    /// 动态目标在后方加载时保持旧静态图可见，避免新 renderer 的未稳定首帧抢到前方。
+    func keepPresentationFront(on screens: [NSScreen]) {
+        for screen in screens {
+            guard let window = imageWindows[screen.wallpaperScreenIdentifier] else { continue }
+            window.orderFrontRegardless()
+            window.displayIfNeeded()
+        }
+        CATransaction.flush()
+    }
+
     /// 返回指定屏幕的静态图原始像素尺寸（供 CropAdjustOverlayController 预览使用）。
     func imageSize(for screen: NSScreen) -> CGSize? {
         imageSizes[screen.wallpaperScreenIdentifier]

--- a/Services/StatusBarController.swift
+++ b/Services/StatusBarController.swift
@@ -496,7 +496,7 @@ final class StatusBarController: NSObject {
 
         // 场景高级设置（仅在实时渲染场景壁纸时显示）
         let shouldShowSceneConfig = weBridge.isCurrentWallpaperScene
-            && UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled")
+            && (UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true)
         sceneConfigItem.isHidden = !shouldShowSceneConfig
         sceneConfigItem.isEnabled = shouldShowSceneConfig
         if shouldShowSceneConfig, let path = weBridge.currentWallpaperPathForDesign {
@@ -865,10 +865,14 @@ final class StatusBarController: NSObject {
     }
 
     private func currentWallpaperURL(for screen: NSScreen) -> URL? {
-        if let videoURL = videoWallpaperManager.videoURL(for: screen) { return videoURL }
+        // “打开当前壁纸”必须严格按屏查询。`videoURL(for:)` 为兼容旧的
+        // 单屏调用会回退到全局 `currentVideoURL`；多屏下目标屏是 Scene/Web、
+        // 其它屏是视频时，这个回退会把其它屏的视频误认成目标屏当前壁纸。
+        if let videoURL = videoWallpaperManager.assignedVideoURL(for: screen) { return videoURL }
         if let rendererPath = weBridge.currentWallpaperPath(for: screen) {
             return URL(fileURLWithPath: rendererPath)
         }
+        if let imageURL = LockScreenWallpaperService.shared.staticImageSourceURL(for: screen) { return imageURL }
         if let imageURL = StaticImageWallpaperOverlayManager.shared.imageURL(for: screen) { return imageURL }
         return DesktopWallpaperSyncManager.shared.imageURL(for: screen)
     }
@@ -1030,7 +1034,7 @@ final class StatusBarController: NSObject {
         }
         if weBridge.isCurrentWallpaperScene {
             // 实时渲染模式下，显示属性编辑面板；否则显示文本设计面板
-            if UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled") {
+            if UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true {
                 presentEditorPopover { anchorView in
                     WebPropertyEditorPanelController.shared.presentScene(for: wallpaperPath, from: anchorView)
                 }

--- a/Services/VideoWallpaperManager.swift
+++ b/Services/VideoWallpaperManager.swift
@@ -120,6 +120,14 @@ final class VideoWallpaperManager: ObservableObject {
     /// 单屏切换会在新 player 创建前更新全局 URL，从而把旧共享管线误认成新文件。
     /// 一个 player 从创建到释放始终锚定同一个物理文件；屏幕引用由 `players` 映射管理。
     private var anchoredVideoPathByPlayerID: [ObjectIdentifier: String] = [:]
+    /// AVPlayerLooper 可能在下一个 run loop 才把 template item 复制进队列。
+    /// 保留每条管线的源 item，让另一块同时创建的屏幕即使在
+    /// `currentItem == nil` 的窗口期也能立即复用这条解码管线。
+    private var sourceVideoItemByPlayerID: [ObjectIdentifier: AVPlayerItem] = [:]
+    /// 同一文件同时创建多屏时，其它屏幕不立即挂到尚未起播的
+    /// 共享 player。等领头屏首帧后已经连续播放，再逐屏附加。
+    private var pendingSharedFollowerScreenIDsByPlayerID: [ObjectIdentifier: Set<String>] = [:]
+    private var sharedFollowerAttachmentTasks: [ObjectIdentifier: Task<Void, Never>] = [:]
     /// 全局同源视频切换采用双代管线：旧共享 player 保持可见，新共享 player
     /// 在每屏隐藏 layer 中预热；所有 layer 都有首帧后再统一黑场交接。
     private var globalTransitionGeneration: UInt64 = 0
@@ -140,6 +148,11 @@ final class VideoWallpaperManager: ObservableObject {
         let fingerprint: String
     }
     private var screenTransitionSourceRollbacks: [String: ScreenTransitionSourceRollback] = [:]
+    /// Scene/Web/独立静态图 → 视频：旧内容保留到新 AVPlayerLayer 首帧可显示。
+    private var pendingCrossTypeVideoScreenIDs = Set<String>()
+    /// 只有已经完成首帧提交的窗口才是“可保留的旧视频”。正在后方预热的窗口
+    /// 不能被下一次 Scene/Web 切换提到前台，否则其黑色 freeze layer 会形成长黑场。
+    private var presentedVideoScreenIDs = Set<String>()
     private struct GlobalTransitionSourceRollback {
         let currentVideoURL: URL?
         let currentPosterURL: URL?
@@ -431,6 +444,28 @@ final class VideoWallpaperManager: ObservableObject {
     /// 是否有任何屏幕正在运行视频壁纸（内部 guard 使用，不依赖全局单例）
     private var hasActiveVideoWallpaper: Bool {
         !videoURLByScreen.isEmpty || !videoURLByScreenFingerprint.isEmpty
+    }
+
+    /// 跨类型切换在新内容准备期间需要保留旧视频窗口。调用方用这个快照决定
+    /// 是立即 teardown，还是等新内容首帧就绪后再在黑场内提交。
+    func hasNativeVideoWallpaper(on screens: [NSScreen]) -> Bool {
+        screens.contains { screen in
+            let screenID = screen.wallpaperScreenIdentifier
+            return presentedVideoScreenIDs.contains(screenID) && windows[screenID] != nil
+        }
+    }
+
+    /// Scene/Web 会在旧视频仍播放时创建同级 desktop window。加载窗口默认会被
+    /// WindowServer 放到同层最前，造成“新第一帧闪一下再进黑场”。准备阶段周期性
+    /// 把旧视频窗提回最前即可让新内容在后方持续播放、完全不可见地预热。
+    func keepNativeVideoPresentationFront(on screens: [NSScreen]) {
+        for screen in screens {
+            guard presentedVideoScreenIDs.contains(screen.wallpaperScreenIdentifier) else { continue }
+            guard let entry = existingVideoWindowEntry(for: screen) else { continue }
+            entry.window.orderFrontRegardless()
+            entry.window.displayIfNeeded()
+        }
+        CATransaction.flush()
     }
 
     /// 将 `currentVideoURL` 与每屏视频状态同步，
@@ -990,29 +1025,35 @@ final class VideoWallpaperManager: ObservableObject {
             cancelPendingGlobalVideoTransition(reason: "supersededByNewApply")
         }
 
-        // 设视频壁纸时关闭并清除静态图 overlay（视频窗口本身覆盖桌面，静态 overlay 无意义且浪费窗口）
-        // 单屏切换只清目标屏，避免副屏自动轮换时误拆掉其它屏的静态 overlay。
-        if let targetScreen {
-            StaticImageWallpaperOverlayManager.shared.clearState(for: targetScreen)
-        } else {
-            StaticImageWallpaperOverlayManager.shared.clearState()
-        }
         let captureScreens: [NSScreen]
         if let targetScreen {
             captureScreens = [targetScreen]
         } else {
             captureScreens = NSScreen.screens
         }
+        WallpaperEngineXBridge.shared.prepareForNonExternalWallpaperSwitch(
+            on: captureScreens,
+            reason: "applyVideoWallpaper"
+        )
         DesktopWallpaperSyncManager.shared.captureOriginalSystemWallpaperIfNeeded(for: captureScreens)
 
-        // 本机视频不经过 CLI：如果设到全局或目标屏幕恰好被 CLI 管理时 stop CLI。
-        // 多屏场景下，如果 CLI 正在渲染另一块屏的壁纸而本屏不需要 CLI，不杀 CLI 进程。
-        if let targetScreen {
-            if WallpaperEngineXBridge.shared.isManaging(screen: targetScreen) {
-                WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaper(for: targetScreen)
+        // Scene/Web/独立静态图 → 视频也必须先预热视频首帧。逐屏记录，避免一块
+        // 显示器的切换提前拆掉另一块显示器仍在播放的旧内容。
+        for screen in captureScreens {
+            let screenID = screen.wallpaperScreenIdentifier
+            let hasExternalRenderer = WallpaperEngineXBridge.shared.hasLivePresentation(on: screen)
+            let hasStaticOverlay = StaticImageWallpaperOverlayManager.shared.hasActiveWallpaper(on: [screen])
+            if animatedTransition && (hasExternalRenderer || hasStaticOverlay) {
+                pendingCrossTypeVideoScreenIDs.insert(screenID)
+                StaticImageWallpaperOverlayManager.shared.keepPresentationFront(on: [screen])
+                continue
             }
-        } else {
-            WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaper()
+
+            pendingCrossTypeVideoScreenIDs.remove(screenID)
+            StaticImageWallpaperOverlayManager.shared.clearState(for: screen)
+            if hasExternalRenderer {
+                WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaper(for: screen)
+            }
         }
 
         let playbackModeChanged = self.usesSharedVideoDecoder != usesSharedVideoDecoder
@@ -1059,12 +1100,10 @@ final class VideoWallpaperManager: ObservableObject {
            videoTargetScreenIDs.isSubset(of: screenIDsNow),
            !targetDisplayConfigurationChanged,
            !playbackModeChanged {
-            // 已起播同一视频但每屏各有一路解码时，把多份 AVQueuePlayer 合并成一路。
-            // 否则「再设一次同样壁纸」会 early-return，VTDecoderXPCService 仍是多份。
-            let coalesced = coalesceDuplicateDecodersForSameVideos()
             if usesSharedVideoDecoder && !self.usesSharedVideoDecoder {
                 self.usesSharedVideoDecoder = true
             }
+            let coalesced = coalesceDuplicateDecodersForSameVideos()
             purgeOrphanedVideoPlayers(reason: coalesced ? "reuseExistingCoalesced" : "reuseExisting")
             synchronizeExistingWindowFramesToCurrentScreens()
             currentVideoURL = localFileURL
@@ -1121,7 +1160,7 @@ final class VideoWallpaperManager: ObservableObject {
             )
         } else if targetScreen == nil,
                   animatedTransition,
-                  usesSharedVideoDecoder,
+                  (usesSharedVideoDecoder || NSScreen.screens.count == 1),
                   !windows.isEmpty {
             globalTransitionSourceRollback = GlobalTransitionSourceRollback(
                 currentVideoURL: currentVideoURL,
@@ -1999,8 +2038,13 @@ final class VideoWallpaperManager: ObservableObject {
         }
         windows.removeAll()
         players.removeAll()
+        presentedVideoScreenIDs.removeAll()
         loopers.removeAll()
+        sharedFollowerAttachmentTasks.values.forEach { $0.cancel() }
+        sharedFollowerAttachmentTasks.removeAll()
+        pendingSharedFollowerScreenIDsByPlayerID.removeAll()
         anchoredVideoPathByPlayerID.removeAll()
+        sourceVideoItemByPlayerID.removeAll()
         sharedVideoLooper?.disableLooping()
         sharedVideoLooper = nil
         sharedVideoItem = nil
@@ -2176,6 +2220,9 @@ final class VideoWallpaperManager: ObservableObject {
     /// 彻底拆掉一条不再被任何屏引用的解码管线（looper + items + layer）。
     /// 用于切换壁纸时避免 VTDecoderXPCService 随每次设置累积。
     private func disposePlayerPipeline(_ player: AVQueuePlayer, looper: AVPlayerLooper? = nil) {
+        let playerID = ObjectIdentifier(player)
+        sharedFollowerAttachmentTasks.removeValue(forKey: playerID)?.cancel()
+        pendingSharedFollowerScreenIDsByPlayerID.removeValue(forKey: playerID)
         detachPlayerFromAllLayers(player)
         looper?.disableLooping()
         if player === sharedVideoPlayer {
@@ -2192,7 +2239,8 @@ final class VideoWallpaperManager: ObservableObject {
         // looper 可能还往 queue 里插 item：先 disable 再清队列。
         player.removeAllItems()
         player.replaceCurrentItem(with: nil)
-        anchoredVideoPathByPlayerID.removeValue(forKey: ObjectIdentifier(player))
+        anchoredVideoPathByPlayerID.removeValue(forKey: playerID)
+        sourceVideoItemByPlayerID.removeValue(forKey: playerID)
         retainPlayersTemporarily([player])
     }
 
@@ -2257,8 +2305,13 @@ final class VideoWallpaperManager: ObservableObject {
         fadeInTimeouts[screenID]?.cancel()
         fadeInTimeouts.removeValue(forKey: screenID)
         screenTransitionSourceRollbacks.removeValue(forKey: screenID)
+        pendingCrossTypeVideoScreenIDs.remove(screenID)
+        presentedVideoScreenIDs.remove(screenID)
 
         let playerBeforeRemoval = players[screenID]
+        if let playerBeforeRemoval {
+            pendingSharedFollowerScreenIDsByPlayerID[ObjectIdentifier(playerBeforeRemoval)]?.remove(screenID)
+        }
         let ownedPlaybackEndObserver = playbackEndObservers[screenID]
         if let observer = ownedPlaybackEndObserver {
             NotificationCenter.default.removeObserver(observer)
@@ -2656,6 +2709,11 @@ final class VideoWallpaperManager: ObservableObject {
             defaults.removeObject(forKey: stateKey)
             return
         }
+
+        WallpaperEngineXBridge.shared.prepareForNonExternalWallpaperSwitch(
+            on: NSScreen.screens,
+            reason: "restoreVideoWallpaper"
+        )
 
         // 恢复预览图 URL（兼容旧版单例 poster）
         let globalPosterURL = savedState.posterURL.flatMap { URL(string: $0) }
@@ -3289,18 +3347,34 @@ final class VideoWallpaperManager: ObservableObject {
 
         // 全局同源视频切换不能 teardown：旧共享解码必须一直播放到新共享解码首帧就绪。
         if targetScreen == nil {
+            // 单显示器的“全局切换”不会开启 shared decoder，但同样必须保留旧
+            // player 到新视频 preroll 完成。此前这里强制要求 shared=true，导致
+            // 单屏全局路径先 teardown 旧窗口，慢视频的整个加载期都暴露纯黑。
             let canStageGlobalTransition = animatedTransition
-                && usesSharedVideoDecoder
+                && (usesSharedVideoDecoder || screensToRebuild.count == 1)
                 && !windows.isEmpty
+                && screensToRebuild.allSatisfy {
+                    presentedVideoScreenIDs.contains($0.wallpaperScreenIdentifier)
+                }
                 && screensToRebuild.allSatisfy { windows[$0.wallpaperScreenIdentifier]?.contentView is WallpaperVideoContainerView }
 
             if canStageGlobalTransition,
                stageGlobalSharedVideoTransition(for: screensToRebuild) {
                 NSLog("[VideoWallpaperManager] Staged global shared-player transition for \(screensToRebuild.count) screen(s)")
             } else {
+                // Scene/Web -> 全屏视频没有旧的本机视频窗口，不能走 shared-player
+                // staging；但 teardownAllWindows 会清理跨类型标记。先保存目标屏标记，
+                // 否则后面 createWindow 会按普通视频路径提前 reveal，旧 Scene 也不会
+                // 在首帧就绪后的黑场内退出。
+                let rebuildingScreenIDs = Set(screensToRebuild.map(\.wallpaperScreenIdentifier))
+                let crossTypeScreenIDs = pendingCrossTypeVideoScreenIDs.intersection(rebuildingScreenIDs)
+                let requestedSharedDecoder = usesSharedVideoDecoder
                 globalTransitionSourceRollback = nil
                 cancelPendingGlobalVideoTransition(reason: "globalImmediateRebuild")
                 teardownAllWindows()
+                pendingCrossTypeVideoScreenIDs.formUnion(crossTypeScreenIDs)
+                // teardown 只是在释放旧窗口，不应改写本次 apply 已决定的解码模式。
+                usesSharedVideoDecoder = requestedSharedDecoder
                 for screen in screensToRebuild {
                     do {
                         guard let videoURL = self.videoURL(for: screen) else { continue }
@@ -3418,13 +3492,11 @@ final class VideoWallpaperManager: ObservableObject {
                     playerItemObserverTokens[targetScreenID] = readinessToken
                     let incomingLayer = containerView.preparePlayerForBlackTransition(components.player)
 
-                    // Hidden warm-up layer must be attached before playback. Wait for
-                    // an actual displayable frame, not merely AVPlayerItem.status.
+                    // Hidden warm-up layer must be attached before decoding. Do not
+                    // start playback yet: first preroll the Looper's real queue item,
+                    // then start it immediately before the short black commit.
                     let screenVolume = volumeByScreen[targetScreenID] ?? volume
                     applyPlayerAudioPolicy(components.player, muted: isMuted, volume: screenVolume)
-                    if !isPaused {
-                        components.player.play()
-                    }
 
                     let beginAnimatedSwap: @MainActor @Sendable (String) -> Void = { [weak self, weak containerView] reason in
                         guard let self, let containerView else { return }
@@ -3442,23 +3514,8 @@ final class VideoWallpaperManager: ObservableObject {
                             components.player.play()
                         }
 
-                        // 后台自动切换：CA completion 可能一直不跑。瞬时 attach + freeze 垫层更稳。
-                        // 前台仍走预热层 + 黑场交接（PR），避免半截空窗。
-                        if !Self.shouldAnimateDesktopPresentation {
-                            CATransaction.begin()
-                            CATransaction.setDisableActions(true)
-                            containerView.cancelPlayerTransitionIfNeeded()
-                            containerView.playerLayer.videoGravity = .resizeAspectFill
-                            containerView.attachPlayer(components.player)
-                            CATransaction.commit()
-                            finalizeReplacement()
-                            if let window = self.windows[targetScreenID] {
-                                Self.revealDesktopWallpaperWindow(window)
-                            }
-                            self.scheduleDisplaySwitchStableRelease(screenID: targetScreenID, reason: "\(reason)ImmediateBackground")
-                            return
-                        }
-
+                        // blackFadeToPreparedPlayer 对 App 未激活状态有显式定时提交，
+                        // 因此菜单栏/自动轮换也保留与前台一致的可见黑场。
                         containerView.blackFadeToPreparedPlayer(
                             components.player,
                             duration: self.automaticSwitchTransitionDuration
@@ -3478,6 +3535,31 @@ final class VideoWallpaperManager: ObservableObject {
                         }
                     }
                     playerItemObservers[targetScreenID] = observer
+
+                    // AVPlayerLooper 的 template item 可能一直是 unknown；应等待其
+                    // currentItem 副本 ready 后 preroll。该条件不依赖隐藏 layer 是否
+                    // 被 WindowServer 合成，慢视频只会让旧壁纸多显示一会，不会拉长黑场。
+                    Task { @MainActor [weak self, weak player = components.player, weak containerView] in
+                        guard let self, let player, containerView != nil else { return }
+                        let deadline = Date().addingTimeInterval(30)
+                        while Date() < deadline {
+                            guard self.playerItemObserverTokens[targetScreenID] == readinessToken else { return }
+                            if let currentItem = player.currentItem {
+                                if currentItem.status == .failed { return }
+                                if currentItem.status == .readyToPlay {
+                                    self.applyPlayerAudioPolicy(player, muted: self.isMuted, volume: screenVolume)
+                                    player.preroll(atRate: 1.0) { success in
+                                        guard success else { return }
+                                        Task { @MainActor in
+                                            beginAnimatedSwap("replacementPrerolled")
+                                        }
+                                    }
+                                    return
+                                }
+                            }
+                            try? await Task.sleep(nanoseconds: 25_000_000)
+                        }
+                    }
 
                     let timeout = DispatchWorkItem { [weak self, weak containerView] in
                         guard let self, let containerView,
@@ -3507,7 +3589,7 @@ final class VideoWallpaperManager: ObservableObject {
                         self.scheduleDisplaySwitchStableRelease(screenID: targetScreenID, reason: "replacementFirstFrameTimeout")
                     }
                     fadeInTimeouts[targetScreenID] = timeout
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 8.0, execute: timeout)
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 30.0, execute: timeout)
                 } else {
                     screenTransitionSourceRollbacks.removeValue(forKey: targetScreenID)
                     containerView.cancelPlayerTransitionIfNeeded()
@@ -3547,9 +3629,9 @@ final class VideoWallpaperManager: ObservableObject {
         NSLog("[VideoWallpaperManager] Windows rebuilt successfully")
     }
 
-    /// Build exactly one incoming AVQueuePlayer for a global same-video apply.
-    /// Existing windows/layers and their old player remain untouched until every
-    /// hidden incoming layer reports a decoded frame ready for display.
+    /// 全局同源切换仍只创建一条解码管线。关键是不能在 player
+    /// 起播前一次挂上所有屏幕的 layer：先让第一屏预热并开始连续播放，
+    /// 再按顺序把其余屏幕加入，与“播放中加入显示器”的已验证路径一致。
     @discardableResult
     private func stageGlobalSharedVideoTransition(for screens: [NSScreen]) -> Bool {
         guard let firstScreen = screens.first,
@@ -3571,6 +3653,7 @@ final class VideoWallpaperManager: ObservableObject {
             for: firstScreen.wallpaperScreenIdentifier
         )
         let isOnEndMode = schedulerConfig.isEnabled && schedulerConfig.isOnEndMode
+
         let components = makePlayerComponents(
             for: firstScreen,
             videoURL: videoURL,
@@ -3581,7 +3664,7 @@ final class VideoWallpaperManager: ObservableObject {
         pendingGlobalTransitionLooper = components.looper
         applyPlayerAudioPolicy(components.player, muted: isMuted, volume: volume)
 
-        var incomingLayers: [String: AVPlayerLayer] = [:]
+        var containersByScreen: [String: WallpaperVideoContainerView] = [:]
         for screen in screens {
             let screenID = screen.wallpaperScreenIdentifier
             guard let window = windows[screenID],
@@ -3590,17 +3673,29 @@ final class VideoWallpaperManager: ObservableObject {
                 return false
             }
             synchronizeWindow(window, to: screen)
-            incomingLayers[screenID] = container.preparePlayerForBlackTransition(components.player)
+            containersByScreen[screenID] = container
         }
 
+        let incomingScreenIDs = Set(containersByScreen.keys)
+        let leaderScreenID = firstScreen.wallpaperScreenIdentifier
+        guard let leaderContainer = containersByScreen[leaderScreenID] else {
+            cancelPendingGlobalVideoTransition(reason: "missingLeader")
+            return false
+        }
+        let leaderLayer = leaderContainer.preparePlayerForBlackTransition(components.player)
+        let warmupStartedAt = Date()
         globalTransitionReadyScreenIDs.removeAll()
         globalTransitionDidBeginCommit = false
         let beginCommitIfReady: @MainActor @Sendable () -> Void = { [weak self] in
             guard let self,
                   self.globalTransitionGeneration == generation,
                   !self.globalTransitionDidBeginCommit,
-                  self.globalTransitionReadyScreenIDs.count == incomingLayers.count else { return }
+                  self.globalTransitionReadyScreenIDs.count == incomingScreenIDs.count else { return }
             self.globalTransitionDidBeginCommit = true
+            AppLogger.debug(.wallpaper, "Global video warmup completed", metadata: [
+                "screens": incomingScreenIDs.sorted().joined(separator: ","),
+                "warmupMS": Int(Date().timeIntervalSince(warmupStartedAt) * 1_000)
+            ])
             self.commitGlobalSharedVideoTransition(
                 generation: generation,
                 screens: screens,
@@ -3612,22 +3707,103 @@ final class VideoWallpaperManager: ObservableObject {
             )
         }
 
-        for (screenID, layer) in incomingLayers {
-            let observer = layer.observe(\.isReadyForDisplay, options: [.initial, .new]) { _, change in
-                guard change.newValue == true else { return }
-                DispatchQueue.main.async {
-                    guard self.globalTransitionGeneration == generation else { return }
-                    self.globalTransitionReadyScreenIDs.insert(screenID)
-                    beginCommitIfReady()
-                }
+        var didBeginFollowerAttachment = false
+        let beginFollowerAttachment: @MainActor @Sendable () -> Void = { [weak self, weak player = components.player] in
+            guard let self, let player,
+                  self.globalTransitionGeneration == generation,
+                  !self.globalTransitionDidBeginCommit,
+                  !didBeginFollowerAttachment else { return }
+            didBeginFollowerAttachment = true
+
+            // 首屏首帧完成后立即播放。先确认时间轴开始推进，
+            // 再挂剩余 layer，不让“同时创建”再停在首帧状态。
+            let initialSeconds = player.currentTime().seconds
+            if !self.isPaused {
+                player.play()
             }
-            globalTransitionObservers.append(observer)
+            Task { @MainActor [weak self, weak player] in
+                guard let self, let player else { return }
+                let playbackDeadline = Date().addingTimeInterval(2.0)
+                var playbackAdvanced = self.isPaused
+                while !playbackAdvanced, Date() < playbackDeadline {
+                    guard self.globalTransitionGeneration == generation,
+                          !self.globalTransitionDidBeginCommit else { return }
+                    let currentSeconds = player.currentTime().seconds
+                    playbackAdvanced = player.rate > 0
+                        && initialSeconds.isFinite
+                        && currentSeconds.isFinite
+                        && currentSeconds - initialSeconds >= 1.0 / 30.0
+                    if !playbackAdvanced {
+                        try? await Task.sleep(for: .milliseconds(16))
+                    }
+                }
+                guard playbackAdvanced else {
+                    AppLogger.error(.wallpaper, "Global shared video leader did not start before follower attach", metadata: [
+                        "initialSeconds": initialSeconds,
+                        "currentSeconds": player.currentTime().seconds,
+                        "rate": player.rate,
+                        "timeControlStatus": player.timeControlStatus.rawValue
+                    ])
+                    return
+                }
+
+                for screen in screens where screen.wallpaperScreenIdentifier != leaderScreenID {
+                    let screenID = screen.wallpaperScreenIdentifier
+                    guard self.globalTransitionGeneration == generation,
+                          !self.globalTransitionDidBeginCommit,
+                          let container = containersByScreen[screenID] else { return }
+                    let layer = container.preparePlayerForBlackTransition(player)
+                    let layerDeadline = Date().addingTimeInterval(5.0)
+                    while Date() < layerDeadline {
+                        guard self.globalTransitionGeneration == generation,
+                              !self.globalTransitionDidBeginCommit else { return }
+                        if layer.isReadyForDisplay {
+                            self.globalTransitionReadyScreenIDs.insert(screenID)
+                            break
+                        }
+                        try? await Task.sleep(for: .milliseconds(16))
+                    }
+                    guard self.globalTransitionReadyScreenIDs.contains(screenID) else { return }
+                }
+                beginCommitIfReady()
+            }
         }
 
-        // The hidden layers must be attached before playback starts; otherwise
-        // AVFoundation may report item-ready without decoding a presentable frame.
-        if !isPaused {
-            components.player.play()
+        let leaderObserver = leaderLayer.observe(\.isReadyForDisplay, options: [.initial, .new]) { _, change in
+            guard change.newValue == true else { return }
+            DispatchQueue.main.async {
+                guard self.globalTransitionGeneration == generation else { return }
+                self.globalTransitionReadyScreenIDs.insert(leaderScreenID)
+                beginFollowerAttachment()
+            }
+        }
+        globalTransitionObservers.append(leaderObserver)
+
+        // 被旧壁纸遮住时 layer KVO 可能不发，所以仍用一次 preroll
+        // 作为首屏准备信号。成功后不等其它 layer，直接起播再加入。
+        Task { @MainActor [weak self, weak player = components.player] in
+            guard let self, let player else { return }
+            let deadline = Date().addingTimeInterval(30)
+            while Date() < deadline {
+                guard self.globalTransitionGeneration == generation,
+                      !self.globalTransitionDidBeginCommit,
+                      self.pendingGlobalTransitionPlayer === player else { return }
+                if let currentItem = player.currentItem, currentItem.status == .readyToPlay {
+                    self.applyPlayerAudioPolicy(player, muted: self.isMuted, volume: self.volume)
+                    player.preroll(atRate: 1.0) { success in
+                        guard success else { return }
+                        Task { @MainActor in
+                            guard self.globalTransitionGeneration == generation,
+                                  !self.globalTransitionDidBeginCommit,
+                                  self.pendingGlobalTransitionPlayer === player else { return }
+                            self.globalTransitionReadyScreenIDs.insert(leaderScreenID)
+                            beginFollowerAttachment()
+                        }
+                    }
+                    return
+                }
+                try? await Task.sleep(nanoseconds: 25_000_000)
+            }
         }
 
         let timeout = DispatchWorkItem { [weak self] in
@@ -3639,7 +3815,7 @@ final class VideoWallpaperManager: ObservableObject {
             self.cancelPendingGlobalVideoTransition(reason: "firstFrameTimeout")
         }
         globalTransitionTimeout = timeout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 8.0, execute: timeout)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 30.0, execute: timeout)
         return true
     }
 
@@ -3654,6 +3830,7 @@ final class VideoWallpaperManager: ObservableObject {
     ) {
         guard globalTransitionGeneration == generation,
               pendingGlobalTransitionPlayer === components.player else { return }
+        let blackCommitStartedAt = Date()
 
         globalTransitionObservers.forEach { $0.invalidate() }
         globalTransitionObservers.removeAll()
@@ -3661,8 +3838,9 @@ final class VideoWallpaperManager: ObservableObject {
         globalTransitionTimeout = nil
         globalTransitionReadyScreenIDs.removeAll()
 
-        // Promote the new generation only after first-frame readiness. Every
-        // screen points at the exact same player/item/looper tuple.
+        // Promote the one warmed decode pipeline only after every screen has joined it.
+        let previousSharedPlayer = sharedVideoPlayer
+        let previousSharedLooper = sharedVideoLooper
         for observer in playbackEndObservers.values {
             NotificationCenter.default.removeObserver(observer)
         }
@@ -3710,6 +3888,7 @@ final class VideoWallpaperManager: ObservableObject {
                     containerView: container
                 )
                 Self.revealDesktopWallpaperWindow(window)
+                self.presentedVideoScreenIDs.insert(screenID)
             }
             guard self.globalTransitionPendingCompletionScreenIDs.isEmpty else { return }
 
@@ -3717,10 +3896,16 @@ final class VideoWallpaperManager: ObservableObject {
             for (oldScreenID, oldPlayer) in oldPlayersByScreen where oldPlayer !== components.player {
                 let id = ObjectIdentifier(oldPlayer)
                 guard released.insert(id).inserted else { continue }
-                self.releasePlayerIfUnreferenced(oldPlayer, looper: oldLoopersByScreen[oldScreenID])
+                let oldLooper = oldLoopersByScreen[oldScreenID]
+                    ?? (oldPlayer === previousSharedPlayer ? previousSharedLooper : nil)
+                self.releasePlayerIfUnreferenced(oldPlayer, looper: oldLooper)
             }
             self.purgeOrphanedVideoPlayers(reason: "globalBlackTransitionComplete")
             self.persistState()
+            AppLogger.debug(.wallpaper, "Global video black transition completed", metadata: [
+                "screens": screens.map(\.wallpaperScreenIdentifier).sorted().joined(separator: ","),
+                "blackMS": Int(Date().timeIntervalSince(blackCommitStartedAt) * 1_000)
+            ])
             NSLog("[VideoWallpaperManager] Global shared-player black transition completed")
         }
 
@@ -3772,7 +3957,9 @@ final class VideoWallpaperManager: ObservableObject {
             player.pause()
             player.removeAllItems()
             player.replaceCurrentItem(with: nil)
-            anchoredVideoPathByPlayerID.removeValue(forKey: ObjectIdentifier(player))
+            let playerID = ObjectIdentifier(player)
+            anchoredVideoPathByPlayerID.removeValue(forKey: playerID)
+            sourceVideoItemByPlayerID.removeValue(forKey: playerID)
             retainPlayersTemporarily([player])
             NSLog("[VideoWallpaperManager] Cancelled pending global transition: \(reason)")
         }
@@ -3858,6 +4045,9 @@ final class VideoWallpaperManager: ObservableObject {
         }
         if let timeout = fadeInTimeouts.removeValue(forKey: oldScreenID) {
             fadeInTimeouts[newScreenID] = timeout
+        }
+        if presentedVideoScreenIDs.remove(oldScreenID) != nil {
+            presentedVideoScreenIDs.insert(newScreenID)
         }
         if let posterToken = posterDisplayTokens.removeValue(forKey: oldScreenID) {
             posterDisplayTokens[newScreenID] = posterToken
@@ -3962,6 +4152,7 @@ final class VideoWallpaperManager: ObservableObject {
             let canonicalItem = (canonicalPlayer === sharedVideoPlayer ? sharedVideoItem : nil)
                 ?? canonicalPlayer.currentItem
                 ?? canonicalPlayer.items().first
+                ?? sourceVideoItemByPlayerID[ObjectIdentifier(canonicalPlayer)]
 
             for screenID in screenIDs where screenID != canonicalScreenID {
                 guard let window = windows[screenID],
@@ -4077,7 +4268,12 @@ final class VideoWallpaperManager: ObservableObject {
             // Loop vs 播完即换 需要不同的 queue/observer 行为，不可混用同一 player。
             // existingIsOnEnd == true  ⇒ enableLooping 必须 false；反之亦然。
             guard existingIsOnEnd == !enableLooping else { continue }
-            guard let item = player.currentItem ?? player.items().first else { continue }
+            // Looper 刚创建时 queue 可能还是空的。以前这里直接
+            // continue，导致“同时设置两屏同文件”各建一条解码管线；
+            // 等第一屏已播放后再加入却正常，就是这个时序窗口。
+            guard let item = player.currentItem
+                    ?? player.items().first
+                    ?? sourceVideoItemByPlayerID[ObjectIdentifier(player)] else { continue }
 
             let looper: AVPlayerLooper?
             if player === sharedVideoPlayer {
@@ -4118,6 +4314,92 @@ final class VideoWallpaperManager: ObservableObject {
         players.compactMap { screenID, candidate in
             candidate === player ? screenID : nil
         }
+    }
+
+    private func enqueueSharedFollowerAttachment(screenID: String, player: AVQueuePlayer) {
+        let playerID = ObjectIdentifier(player)
+        pendingSharedFollowerScreenIDsByPlayerID[playerID, default: []].insert(screenID)
+        scheduleSharedFollowerAttachments(for: player)
+    }
+
+    /// 严格复制“单屏已播放后再加入屏幕”的成功路径。
+    /// 共享 player 时间轴未推进前不附加 follower layer；每加一屏
+    /// 都等它首帧 ready 后再加下一屏，避免同一 run loop 批量挂层。
+    private func scheduleSharedFollowerAttachments(for player: AVQueuePlayer) {
+        let playerID = ObjectIdentifier(player)
+        guard sharedFollowerAttachmentTasks[playerID] == nil else { return }
+
+        let task = Task { @MainActor [weak self, weak player] in
+            guard let self, let player else { return }
+            let initialSeconds = player.currentTime().seconds
+            let playbackDeadline = Date().addingTimeInterval(30)
+            var playbackAdvanced = self.isPaused
+            while !playbackAdvanced, Date() < playbackDeadline {
+                guard self.screenIDsReferencingPlayer(player).count >= 2 else {
+                    self.pendingSharedFollowerScreenIDsByPlayerID.removeValue(forKey: playerID)
+                    self.sharedFollowerAttachmentTasks.removeValue(forKey: playerID)
+                    return
+                }
+                let currentSeconds = player.currentTime().seconds
+                playbackAdvanced = player.rate > 0
+                    && initialSeconds.isFinite
+                    && currentSeconds.isFinite
+                    && currentSeconds - initialSeconds >= 1.0 / 30.0
+                if !playbackAdvanced {
+                    try? await Task.sleep(for: .milliseconds(16))
+                }
+            }
+
+            guard playbackAdvanced else {
+                AppLogger.error(.wallpaper, "Shared video leader did not start before follower attach", metadata: [
+                    "owners": self.screenIDsReferencingPlayer(player).sorted().joined(separator: ","),
+                    "rate": player.rate,
+                    "timeControlStatus": player.timeControlStatus.rawValue
+                ])
+                self.sharedFollowerAttachmentTasks.removeValue(forKey: playerID)
+                return
+            }
+
+            while let screenID = self.pendingSharedFollowerScreenIDsByPlayerID[playerID]?.sorted().first {
+                self.pendingSharedFollowerScreenIDsByPlayerID[playerID]?.remove(screenID)
+                guard self.players[screenID] === player,
+                      let window = self.windows[screenID],
+                      let container = window.contentView as? WallpaperVideoContainerView else {
+                    continue
+                }
+
+                container.attachPlayer(player)
+                CATransaction.flush()
+                AppLogger.debug(.wallpaper, "Shared video follower attached after leader playback", metadata: [
+                    "screenID": screenID,
+                    "currentSeconds": player.currentTime().seconds,
+                    "rate": player.rate
+                ])
+
+                let layerDeadline = Date().addingTimeInterval(5)
+                while Date() < layerDeadline, !container.playerLayer.isReadyForDisplay {
+                    guard self.players[screenID] === player else { break }
+                    try? await Task.sleep(for: .milliseconds(16))
+                }
+                guard self.players[screenID] === player,
+                      container.playerLayer.isReadyForDisplay else {
+                    AppLogger.error(.wallpaper, "Shared video follower layer did not become ready", metadata: [
+                        "screenID": screenID,
+                        "currentSeconds": player.currentTime().seconds
+                    ])
+                    break
+                }
+            }
+
+            if self.pendingSharedFollowerScreenIDsByPlayerID[playerID]?.isEmpty != false {
+                self.pendingSharedFollowerScreenIDsByPlayerID.removeValue(forKey: playerID)
+            }
+            self.sharedFollowerAttachmentTasks.removeValue(forKey: playerID)
+            if self.pendingSharedFollowerScreenIDsByPlayerID[playerID]?.isEmpty == false {
+                self.scheduleSharedFollowerAttachments(for: player)
+            }
+        }
+        sharedFollowerAttachmentTasks[playerID] = task
     }
 
     /// When a larger display attaches to a shared decode pipeline, raise the item's
@@ -4301,7 +4583,9 @@ final class VideoWallpaperManager: ObservableObject {
             queuePlayer.insert(playerItem, after: nil)
         }
 
-        anchoredVideoPathByPlayerID[ObjectIdentifier(queuePlayer)] = videoURL.standardizedFileURL.path
+        let playerID = ObjectIdentifier(queuePlayer)
+        anchoredVideoPathByPlayerID[playerID] = videoURL.standardizedFileURL.path
+        sourceVideoItemByPlayerID[playerID] = playerItem
 
         return (queuePlayer, looper, playerItem)
     }
@@ -4374,10 +4658,18 @@ final class VideoWallpaperManager: ObservableObject {
             muted: muted,
             enableLooping: !isOnEndMode
         )
+        // 同一次多屏应用会依次进入 createWindow，但所有屏拿到的是同一个
+        // AVQueuePlayer。只有第一个引用者可以负责启动这条共享管线的 preroll；
+        // 若每个屏都同时对同一个尚未启动的 player 调 preroll，部分视频会让
+        // AVFoundation 的启动回调互相等待，表现为两个屏一起设置时永久卡首帧。
+        // 后续屏只观察自己的 AVPlayerLayer，领头屏开始播放后自然收到首帧。
+        let isSharedWarmupFollower = !screenIDsReferencingPlayer(components.player).isEmpty
         assignPlayerComponents(components, to: screenID)
 
         containerView.playerLayer.videoGravity = .resizeAspectFill
-        containerView.attachPlayer(components.player)
+        if !isSharedWarmupFollower {
+            containerView.attachPlayer(components.player)
+        }
 
         // 异步加载视频真实尺寸并缓存，加载完后重算 crop（首次用 fallback 屏尺寸）。
         Task { [weak self, videoURL] in
@@ -4411,46 +4703,162 @@ final class VideoWallpaperManager: ObservableObject {
             containerView: containerView
         )
 
-        // 先隐藏窗口，等视频首帧就绪后再显现，避免启动时闪黑
-        window.alphaValue = 0
+        // 跨类型启动放在旧 Web/Scene 后方预热。普通启动也不能用严格 alpha=0，
+        // 否则桌面层窗口可能拿不到 WindowServer surface，AVPlayerLayer 的首帧
+        // 就绪事件永远不来；用近透明值保持可合成，首帧到达后再正式 reveal。
+        let isCrossTypeWarmup = pendingCrossTypeVideoScreenIDs.contains(screenID)
+        window.alphaValue = isCrossTypeWarmup ? 1 : 0.01
         window.orderBack(nil)
 
         // 视频加载期间先显示封面图，避免黑屏（同步关闭时尤为关键）
         showPosterImage(for: screenID)
 
-        // 观察 playerItem 状态，就绪后播放并显现
+        // AVPlayerLooper 会复制 templateItem 放进队列；传入 Looper 的原始 item
+        // 可能永远保持 .unknown，即使队列里的副本已经能够解码。因此不能等待
+        // components.item.status 再调用 play。先在旧壁纸后方启动解码，并直接以
+        // AVPlayerLayer 的首个可显示帧作为提交条件。
         let player = components.player
-        let observer = components.item.observe(\.status, options: [.initial]) { [weak self] item, _ in
-            guard let self, item.status == .readyToPlay else { return }
-            Task { @MainActor in
-                // 清理 observer 和超时
-                self.playerItemObservers[screenID]?.invalidate()
-                self.playerItemObservers.removeValue(forKey: screenID)
-                self.playerItemObserverTokens.removeValue(forKey: screenID)
-                self.fadeInTimeouts[screenID]?.cancel()
-                self.fadeInTimeouts.removeValue(forKey: screenID)
-                // 视频就绪，隐藏封面图
-                self.hidePosterImage(for: screenID)
-                // 首帧 ready 后、真正播放前再次同步音频策略，覆盖 looper 后续插入的 item。
-                let screenVolume = self.volumeByScreen[screenID] ?? self.volume
-                self.applyPlayerAudioPolicy(player, muted: self.isMuted, volume: screenVolume)
-                // 仅在非暂停状态下播放（restoreIfNeeded 中可能已设为暂停）
-                if !self.isPaused {
-                    player.play()
+        // 同一屏幕可能在前一个 AVPlayerItem 尚未 ready 时再次收到“下一张/设置”请求。
+        // 旧 KVO 回调和旧超时不能仅凭 screenID 操作，否则会误删后一次请求刚创建的
+        // window / observer，最终表现为连续点击后当前壁纸再也切不走。
+        let readinessToken = UUID()
+        playerItemObserverTokens[screenID] = readinessToken
+        let presentPreparedVideo: @MainActor @Sendable () async -> Void = { [weak self, weak window] in
+            guard let self, let window,
+                  self.playerItemObserverTokens[screenID] == readinessToken,
+                  self.windows[screenID] === window else { return }
+            // 清理 observer 和超时
+            self.playerItemObservers[screenID]?.invalidate()
+            self.playerItemObservers.removeValue(forKey: screenID)
+            self.playerItemObserverTokens.removeValue(forKey: screenID)
+            self.fadeInTimeouts[screenID]?.cancel()
+            self.fadeInTimeouts.removeValue(forKey: screenID)
+            // 预卷或真实 layer 首帧已经完成，此时才移除封面并提交切换。
+            self.hidePosterImage(for: screenID)
+            // Looper 可能在预热期间插入新的循环 item，提交前再次同步音频策略。
+            let screenVolume = self.volumeByScreen[screenID] ?? self.volume
+            self.applyPlayerAudioPolicy(player, muted: self.isMuted, volume: screenVolume)
+            if !self.isPaused {
+                player.play()
+            }
+            if self.screenIDsReferencingPlayer(player).count > 1 {
+                self.scheduleSharedFollowerAttachments(for: player)
+            }
+
+            if self.pendingCrossTypeVideoScreenIDs.contains(screenID) {
+                self.pendingCrossTypeVideoScreenIDs.remove(screenID)
+                guard let transitionScreen = NSScreen.screens.first(where: {
+                    $0.wallpaperScreenIdentifier == screenID
+                }) else {
+                    self.teardownWindow(for: screenID)
+                    return
                 }
-                self.presentDesktopWallpaperWindow(window, animated: Self.shouldAnimateDesktopPresentation)
-                self.scheduleDisplaySwitchStableRelease(screenID: screenID, reason: "windowReady")
+                await WallpaperCrossTypeTransitionCoordinator.shared.commitPreparedContent(on: [transitionScreen]) {
+                    await WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaperForTransition(
+                        for: transitionScreen
+                    )
+                    StaticImageWallpaperOverlayManager.shared.clearState(for: transitionScreen)
+                    Self.revealDesktopWallpaperWindow(window)
+                    window.orderFrontRegardless()
+                }
+                self.presentedVideoScreenIDs.insert(screenID)
+                self.scheduleDisplaySwitchStableRelease(screenID: screenID, reason: "crossTypeVideoReady")
+                return
+            }
+
+            self.presentDesktopWallpaperWindow(window, animated: Self.shouldAnimateDesktopPresentation)
+            self.presentedVideoScreenIDs.insert(screenID)
+            self.scheduleDisplaySwitchStableRelease(screenID: screenID, reason: "windowReady")
+        }
+
+        let observer = containerView.playerLayer.observe(\.isReadyForDisplay, options: [.initial, .new]) { _, change in
+            guard change.newValue == true else { return }
+            Task { @MainActor in
+                await presentPreparedVideo()
             }
         }
         playerItemObservers[screenID] = observer
 
-        // 超时保护：3 秒后如果视频仍未就绪，强制显现
+        // Looper 异步把 templateItem 的副本放入队列。窗口在旧 Scene/Web 后方时，
+        // WindowServer 可能对完全遮挡的 AVPlayerLayer 做合成裁剪，导致 layer 的
+        // isReadyForDisplay 永远不变。等待真实 currentItem 后用 AVPlayer.preroll；
+        // preroll 完成代表媒体已准备播放，不依赖窗口可见性，随后才开始短黑场。
+        let warmupVolume = volumeByScreen[screenID] ?? volume
+        applyPlayerAudioPolicy(player, muted: isMuted, volume: warmupVolume)
+        if !isSharedWarmupFollower {
+            Task { @MainActor [weak self, weak player, weak window] in
+                guard let self, let player, let window else { return }
+                let deadline = Date().addingTimeInterval(30)
+                while Date() < deadline {
+                    guard self.playerItemObserverTokens[screenID] == readinessToken,
+                          self.windows[screenID] === window else { return }
+                    if let currentItem = player.currentItem {
+                        if currentItem.status == .failed {
+                            AppLogger.error(.wallpaper, "Video warmup item failed", metadata: [
+                                "screenID": screenID,
+                                "video": videoURL.lastPathComponent,
+                                "error": currentItem.error?.localizedDescription ?? "nil"
+                            ])
+                            return
+                        }
+                        if currentItem.status == .readyToPlay {
+                            self.applyPlayerAudioPolicy(player, muted: self.isMuted, volume: warmupVolume)
+                            player.preroll(atRate: 1.0) { success in
+                                guard success else { return }
+                                Task { @MainActor in
+                                    await presentPreparedVideo()
+                                }
+                            }
+                            return
+                        }
+                    }
+                    try? await Task.sleep(nanoseconds: 25_000_000)
+                }
+            }
+        } else {
+            AppLogger.debug(.wallpaper, "Shared video follower waiting for leader warmup", metadata: [
+                "screenID": screenID,
+                "video": videoURL.lastPathComponent,
+                "owners": screenIDsReferencingPlayer(player).filter { $0 != screenID }.sorted().joined(separator: ",")
+            ])
+            enqueueSharedFollowerAttachment(screenID: screenID, player: player)
+        }
+        AppLogger.debug(.wallpaper, "Video first-frame warmup started", metadata: [
+            "screenID": screenID,
+            "video": videoURL.lastPathComponent,
+            "crossType": isCrossTypeWarmup,
+            "sharedFollower": isSharedWarmupFollower,
+            "queueItems": player.items().count,
+            "templateStatus": components.item.status.rawValue
+        ])
+
+        // 这里只是损坏文件/解码器无响应的最终保护。正常提交完全由真实首帧触发，
+        // 不再依赖 templateItem.status 或人为延时。
+        let itemReadyTimeout: TimeInterval = (isCrossTypeWarmup || isSharedWarmupFollower) ? 30.0 : 12.0
         let timeout = DispatchWorkItem { [weak self] in
-            guard let self, self.playerItemObservers[screenID] != nil else { return }
+            guard let self,
+                  self.playerItemObserverTokens[screenID] == readinessToken,
+                  self.windows[screenID] === window,
+                  self.playerItemObservers[screenID] != nil else { return }
             self.playerItemObservers[screenID]?.invalidate()
             self.playerItemObservers.removeValue(forKey: screenID)
             self.playerItemObserverTokens.removeValue(forKey: screenID)
             self.fadeInTimeouts.removeValue(forKey: screenID)
+            if self.pendingCrossTypeVideoScreenIDs.remove(screenID) != nil {
+                AppLogger.error(.wallpaper, "Cross-type video first-frame timeout", metadata: [
+                    "screenID": screenID,
+                    "video": videoURL.lastPathComponent,
+                    "timeout": itemReadyTimeout,
+                    "templateStatus": components.item.status.rawValue,
+                    "currentItemStatus": player.currentItem?.status.rawValue ?? -1,
+                    "itemError": player.currentItem?.error?.localizedDescription
+                        ?? components.item.error?.localizedDescription
+                        ?? "nil"
+                ])
+                self.teardownWindow(for: screenID)
+                NSLog("[VideoWallpaperManager] Cross-type video first-frame timeout on \(screenID); old wallpaper kept visible")
+                return
+            }
             // 超时兜底，隐藏封面图
             self.hidePosterImage(for: screenID)
             // ready 超时时也会直接播放，所以这里同样要先禁用静音状态下的音频轨。
@@ -4461,10 +4869,11 @@ final class VideoWallpaperManager: ObservableObject {
             }
             // 超时路径一律瞬时显现，避免后台再卡在 animator 上。
             self.presentDesktopWallpaperWindow(window, animated: false)
+            self.presentedVideoScreenIDs.insert(screenID)
             self.scheduleDisplaySwitchStableRelease(screenID: screenID, reason: "windowReadyTimeout")
         }
         fadeInTimeouts[screenID] = timeout
-        DispatchQueue.main.asyncAfter(deadline: .now() + 3, execute: timeout)
+        DispatchQueue.main.asyncAfter(deadline: .now() + itemReadyTimeout, execute: timeout)
 
         // 如果是"播完即换"模式，添加视频播放完成的观察者。
         // 共享同一 AVQueuePlayer 时只挂一个 observer，避免 end 事件被重复派发。
@@ -4544,6 +4953,7 @@ final class VideoWallpaperManager: ObservableObject {
 
     private func teardownAllWindows() {
         cancelPendingGlobalVideoTransition(reason: "teardownAllWindows")
+        pendingCrossTypeVideoScreenIDs.removeAll()
         // 0. 取消上一次未执行的延迟释放，避免快速切换时多组 AVPlayer 并发驻留
         pendingPlayerCleanups.forEach { $0.cancel() }
         pendingPlayerCleanups.removeAll()
@@ -4608,7 +5018,11 @@ final class VideoWallpaperManager: ObservableObject {
         players.removeAll()
         transitionRetainedPlayers.removeAll()
         transitionRetainedPlayerOwners.removeAll()
+        sharedFollowerAttachmentTasks.values.forEach { $0.cancel() }
+        sharedFollowerAttachmentTasks.removeAll()
+        pendingSharedFollowerScreenIDsByPlayerID.removeAll()
         anchoredVideoPathByPlayerID.removeAll()
+        sourceVideoItemByPlayerID.removeAll()
         screenTransitionSourceRollbacks.removeAll()
         sharedVideoLooper?.disableLooping()
         sharedVideoLooper = nil
@@ -4634,6 +5048,7 @@ final class VideoWallpaperManager: ObservableObject {
             window.orderOut(nil)
         }
         windows.removeAll()
+        presentedVideoScreenIDs.removeAll()
 
         // 延迟释放窗口，让 AppKit 的 _NSWindowTransformAnimation 退出动画完成。
         // 延迟完成后必须移除 work item，否则闭包会继续持有旧 window。
@@ -5048,6 +5463,165 @@ private enum VideoLetterboxAnalyzer {
         )
     }
 }
+
+/// 视频切到照片 / Scene / Web 时的提交遮罩。
+///
+/// 新内容必须先在旧视频后方完成准备；这里只负责很短的黑场提交窗口，确保旧视频
+/// teardown 与新内容 reveal 发生在黑场最深处。遮罩永远由本方法负责移除，后台切换
+/// 不依赖 AppKit 动画 completion，避免菜单栏“下一张”时黑层永久滞留。
+@MainActor
+final class WallpaperCrossTypeTransitionCoordinator {
+    static let shared = WallpaperCrossTypeTransitionCoordinator()
+
+    private var transitionGenerationByScreen: [String: UInt64] = [:]
+    private var blackWindowsByScreen: [String: NSWindow] = [:]
+
+    private init() {}
+
+    func commitPreparedContent(
+        on screens: [NSScreen],
+        teardownOldContent: @MainActor () async -> Void
+    ) async {
+        let transitionStartedAt = Date()
+        let uniqueScreens = Dictionary(
+            screens.map { ($0.wallpaperScreenIdentifier, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        guard !uniqueScreens.isEmpty else {
+            await teardownOldContent()
+            return
+        }
+
+        var generations: [String: UInt64] = [:]
+        var windowsByScreen: [String: NSWindow] = [:]
+        for (screenID, screen) in uniqueScreens {
+            removeBlackWindow(for: screenID)
+            let generation = (transitionGenerationByScreen[screenID] ?? 0) &+ 1
+            transitionGenerationByScreen[screenID] = generation
+            generations[screenID] = generation
+            let window = makeBlackWindow(for: screen)
+            blackWindowsByScreen[screenID] = window
+            windowsByScreen[screenID] = window
+            window.alphaValue = 0
+            window.orderFrontRegardless()
+            window.displayIfNeeded()
+        }
+        let windows = Array(windowsByScreen.values)
+
+        if NSApp.isActive && NSApp.isRunning {
+            await animate(windows: windows, alpha: 1, duration: 0.14)
+        } else {
+            setAlpha(1, for: windows)
+            // 菜单栏/后台切换时 AppKit alpha 动画不推进，用固定半程保证黑场
+            // 至少实际合成一段时间，而不是只存在一个不可见的 run-loop slice。
+            try? await Task.sleep(nanoseconds: 140_000_000)
+        }
+
+        guard isCurrent(generations: generations) else {
+            removeMatchingBlackWindows(windowsByScreen)
+            return
+        }
+        let teardownStartedAt = Date()
+        await teardownOldContent()
+        // prepared content 的 reveal 可能在相同 desktop level 上调用 orderFront。
+        // 提交后重新把遮罩置顶，确保黑场不会在最深点突然丢失。
+        for window in windows {
+            window.orderFrontRegardless()
+            window.displayIfNeeded()
+        }
+        CATransaction.flush()
+        await Task.yield()
+
+        if NSApp.isActive && NSApp.isRunning {
+            await animate(windows: windows, alpha: 0, duration: 0.14)
+        } else {
+            try? await Task.sleep(nanoseconds: 140_000_000)
+            setAlpha(0, for: windows)
+        }
+
+        guard isCurrent(generations: generations) else {
+            removeMatchingBlackWindows(windowsByScreen)
+            return
+        }
+        removeMatchingBlackWindows(windowsByScreen)
+        AppLogger.debug(.wallpaper, "Cross-type black transition completed", metadata: [
+            "screens": uniqueScreens.keys.sorted().joined(separator: ","),
+            "teardownMS": Int(Date().timeIntervalSince(teardownStartedAt) * 1_000),
+            "totalMS": Int(Date().timeIntervalSince(transitionStartedAt) * 1_000)
+        ])
+    }
+
+    private func makeBlackWindow(for screen: NSScreen) -> NSWindow {
+        let window = NSWindow(
+            contentRect: screen.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false,
+            screen: screen
+        )
+        // 比实际壁纸窗高一级。两者同级时，新内容 orderFront 会盖住黑层，表现为
+        // 全局黑场过渡“丢了”；仍远低于普通应用窗口，不会遮住用户界面。
+        window.level = .init(rawValue: Int(CGWindowLevelForKey(.desktopWindow)) + 1)
+        window.collectionBehavior = [.canJoinAllSpaces, .stationary, .fullScreenAuxiliary, .ignoresCycle]
+        window.isOpaque = true
+        window.backgroundColor = .black
+        window.hasShadow = false
+        window.ignoresMouseEvents = true
+        window.isReleasedWhenClosed = false
+        window.setFrame(screen.frame, display: true)
+        return window
+    }
+
+    private func animate(windows: [NSWindow], alpha: CGFloat, duration: TimeInterval) async {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = duration
+            context.timingFunction = CAMediaTimingFunction(name: .easeInEaseOut)
+            for window in windows {
+                window.animator().alphaValue = alpha
+            }
+        } completionHandler: {}
+        // NSAnimationContext completion 在菜单栏切换/焦点变化时偶发延迟约
+        // 250ms，两个半程叠加后会把短黑场拖到接近 1 秒。按目标时长等待后
+        // 直接锁定最终 alpha；加载时间完全留在黑场之前，提交时长保持确定。
+        let nanoseconds = UInt64(max(0, duration) * 1_000_000_000)
+        try? await Task.sleep(nanoseconds: nanoseconds)
+        setAlpha(alpha, for: windows)
+    }
+
+    private func setAlpha(_ alpha: CGFloat, for windows: [NSWindow]) {
+        CATransaction.begin()
+        CATransaction.setDisableActions(true)
+        for window in windows {
+            window.alphaValue = alpha
+            window.displayIfNeeded()
+        }
+        CATransaction.commit()
+        CATransaction.flush()
+    }
+
+    private func isCurrent(generations: [String: UInt64]) -> Bool {
+        generations.allSatisfy { screenID, generation in
+            transitionGenerationByScreen[screenID] == generation
+        }
+    }
+
+    /// 批量过渡被其中一块屏的新请求取代时，只移除仍属于本批次的窗口。
+    /// 已由新请求接管的屏幕会因为 identity 不匹配而保留新黑层。
+    private func removeMatchingBlackWindows(_ windowsByScreen: [String: NSWindow]) {
+        for (screenID, window) in windowsByScreen {
+            removeBlackWindow(for: screenID, ifMatching: window)
+        }
+    }
+
+    private func removeBlackWindow(for screenID: String, ifMatching expected: NSWindow? = nil) {
+        guard let window = blackWindowsByScreen[screenID],
+              expected == nil || window === expected else { return }
+        window.orderOut(nil)
+        window.close()
+        blackWindowsByScreen.removeValue(forKey: screenID)
+    }
+}
+
 private final class WallpaperVideoContainerView: NSView {
     private var storedPosterLayer: CALayer?
     private var grainOverlayView: NSView?
@@ -5056,7 +5630,7 @@ private final class WallpaperVideoContainerView: NSView {
 
     /// 实际播放视频的 AVPlayerLayer。作为容器 backing layer 的子层，
     /// 通过修改它的 frame 实现 pan/zoom 裁切（容器 backing layer masksToBounds 自然裁剪）。
-    private let avPlayerLayer = AVPlayerLayer()
+    private var avPlayerLayer = AVPlayerLayer()
     /// 垫在 AVPlayerLayer 下方：当 `isReadyForDisplay == false`（looper 切 item / 解码空帧）
     /// 时用最近一帧挡住 window 纯黑底，避免桌面「暗闪一下」而 UI 窗口不受影响。
     private let freezeFrameLayer = CALayer()
@@ -5341,6 +5915,9 @@ private final class WallpaperVideoContainerView: NSView {
     }
 
     func cancelPlayerTransitionIfNeeded() {
+        if avPlayerLayer.isReadyForDisplay {
+            freezeFrameLayer.isHidden = true
+        }
         transitionPlayerLayer?.player = nil
         transitionPlayerLayer?.removeFromSuperlayer()
         transitionPlayerLayer = nil
@@ -5402,6 +5979,8 @@ private final class WallpaperVideoContainerView: NSView {
         blackTransitionLayer = black
 
         var didComplete = false
+        var didInstall = false
+        var didBeginReveal = false
         let finish: () -> Void = { [weak self, weak black] in
             guard !didComplete else { return }
             didComplete = true
@@ -5413,43 +5992,75 @@ private final class WallpaperVideoContainerView: NSView {
             completion()
         }
 
-        let installIncoming: () -> Void = { [weak self, weak incoming] in
+        let installIncoming: () -> Bool = { [weak self, weak incoming] in
+            guard !didInstall else { return true }
+            didInstall = true
             guard let self, let incoming else {
                 finish()
-                return
+                return false
             }
             CATransaction.begin()
             CATransaction.setDisableActions(true)
-            self.avPlayerLayer.videoGravity = incoming.videoGravity
-            // attachPlayer 统一管理主层 + freeze 可见性；不要直接写 avPlayerLayer.player。
-            self.attachPlayer(newPlayer)
-            // 交接瞬间主层可能尚未 isReadyForDisplay，先露 freeze 防揭黑闪一下。
-            self.freezeFrameLayer.isHidden = false
-            incoming.player = nil
-            incoming.removeFromSuperlayer()
+            // 预热层本身已经 ready 且正在连续出帧，直接把它晋升为新的主层。
+            // 不把同一 AVPlayer 重新挂到另一个 AVPlayerLayer，避免输出重建时停在第一帧。
+            let outgoing = self.avPlayerLayer
+            self.readyForDisplayObservation?.invalidate()
+            incoming.opacity = 1
+            self.avPlayerLayer = incoming
             if self.transitionPlayerLayer === incoming {
                 self.transitionPlayerLayer = nil
             }
+            outgoing.player = nil
+            outgoing.removeFromSuperlayer()
+            self.startReadyForDisplayObservation()
+            self.refreshFreezeFrameVisibility()
             CATransaction.commit()
+            CATransaction.flush()
+            return true
         }
 
         let totalDuration = max(0.16, duration)
         let halfDuration = totalDuration / 2
+        let beginRevealWhenReady: () -> Void = { [weak self, weak black] in
+            guard !didBeginReveal, !didComplete, let self, let black else { return }
+            didBeginReveal = true
+            self.waitForMainPlayerToAdvance(player: newPlayer, timeout: 1.5) { [weak self, weak black] in
+                guard !didComplete, let self, let black,
+                      self.blackTransitionLayer === black,
+                      self.avPlayerLayer.player === newPlayer else {
+                    finish()
+                    return
+                }
+                CATransaction.begin()
+                CATransaction.setAnimationDuration(halfDuration)
+                CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
+                black.opacity = 0
+                CATransaction.commit()
+                DispatchQueue.main.asyncAfter(deadline: .now() + halfDuration) {
+                    guard !didComplete else { return }
+                    CATransaction.begin()
+                    CATransaction.setDisableActions(true)
+                    black.opacity = 0
+                    CATransaction.commit()
+                    finish()
+                }
+            }
+        }
         let appActive = NSApp.isActive && NSApp.isRunning
         if !appActive {
-            // Background CA completions are unreliable. Commit an explicit black
-            // frame, swap on the next run-loop slice, then reveal the warm player.
+            // Background CA completions are unreliable. Keep a deterministic short
+            // black interval on both sides of the swap instead of reducing it to one
+            // run-loop slice (which made global/menu-bar transitions look missing).
             CATransaction.begin()
             CATransaction.setDisableActions(true)
             black.opacity = 1
             CATransaction.commit()
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.06) {
-                installIncoming()
-                CATransaction.begin()
-                CATransaction.setDisableActions(true)
-                black.opacity = 0
-                CATransaction.commit()
-                finish()
+            CATransaction.flush()
+            DispatchQueue.main.asyncAfter(deadline: .now() + halfDuration) {
+                guard !didComplete else { return }
+                if installIncoming() {
+                    beginRevealWhenReady()
+                }
             }
             return
         }
@@ -5457,21 +6068,65 @@ private final class WallpaperVideoContainerView: NSView {
         CATransaction.begin()
         CATransaction.setAnimationDuration(halfDuration)
         CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
-        CATransaction.setCompletionBlock {
-            installIncoming()
-            CATransaction.begin()
-            CATransaction.setAnimationDuration(halfDuration)
-            CATransaction.setAnimationTimingFunction(CAMediaTimingFunction(name: .easeInEaseOut))
-            CATransaction.setCompletionBlock { finish() }
-            black.opacity = 0
-            CATransaction.commit()
-        }
         black.opacity = 1
         CATransaction.commit()
 
-        DispatchQueue.main.asyncAfter(deadline: .now() + totalDuration + 0.5) {
-            installIncoming()
-            finish()
+        // CA transaction completion 在桌面窗口/多显示器切换时偶尔会在动画尚未显示前触发，
+        // 造成黑场只有几个毫秒并提前拆预热层。用固定主线程时序提交两段动画。
+        DispatchQueue.main.asyncAfter(deadline: .now() + halfDuration) {
+            guard !didComplete else { return }
+            CATransaction.begin()
+            CATransaction.setDisableActions(true)
+            black.opacity = 1
+            CATransaction.commit()
+            if installIncoming() {
+                beginRevealWhenReady()
+            }
+        }
+    }
+
+    /// 黑场内完成 player 输出层转移后，必须同时确认主层 ready 且播放时间已推进，
+    /// 才能揭开黑场。只检查 isReadyForDisplay 会误收换 player 前遗留的 true。
+    private func waitForMainPlayerToAdvance(
+        player: AVQueuePlayer,
+        timeout: TimeInterval,
+        completion: @escaping () -> Void
+    ) {
+        let startedAt = CACurrentMediaTime()
+        let initialSeconds = player.currentTime().seconds
+        // 实时渲染/自动暂停已让 player 正常处于 paused 时，不强行 play，也不等待时间推进。
+        let expectsPlaybackProgress = player.rate > 0 || player.timeControlStatus != .paused
+        Task { @MainActor [weak self, weak player] in
+            guard let self, let player else { return }
+            let deadline = startedAt + timeout
+            while CACurrentMediaTime() < deadline {
+                guard self.avPlayerLayer.player === player else { return }
+                let currentSeconds = player.currentTime().seconds
+                let advanced = !expectsPlaybackProgress
+                    || (initialSeconds.isFinite && currentSeconds.isFinite
+                        && abs(currentSeconds - initialSeconds) >= 1.0 / 30.0)
+                if CACurrentMediaTime() - startedAt >= 0.05,
+                   self.avPlayerLayer.isReadyForDisplay,
+                   advanced {
+                    self.freezeFrameLayer.isHidden = true
+                    completion()
+                    return
+                }
+                try? await Task.sleep(for: .milliseconds(16))
+            }
+
+            AppLogger.warn(
+                .wallpaper,
+                "Main video layer did not advance before reveal timeout",
+                metadata: [
+                    "layerReady": self.avPlayerLayer.isReadyForDisplay,
+                    "rate": player.rate,
+                    "timeControlStatus": player.timeControlStatus.rawValue,
+                    "currentSeconds": player.currentTime().seconds,
+                    "initialSeconds": initialSeconds
+                ]
+            )
+            completion()
         }
     }
 

--- a/Services/WallpaperEngineXBridge.swift
+++ b/Services/WallpaperEngineXBridge.swift
@@ -190,6 +190,13 @@ final class WallpaperEngineXBridge: ObservableObject {
 
     /// 每个屏幕的 wallpaper-wgpu 进程信息（key = screenID）
     private var screenProcesses: [String: ScreenProcessInfo] = [:]
+    /// 从系统进程表发现的桌面 Scene renderer。它们可能来自上一次崩溃的
+    /// WaifuX，已经不在 `screenProcesses` 中，但窗口仍能重新抢占桌面层。
+    private struct DiscoveredDesktopRenderer {
+        let pid: pid_t
+        let parentPID: pid_t
+        let command: String
+    }
     private let webRenderer = WebRendererBridge.shared
     private enum RenderKind: String, Codable {
         case scene
@@ -268,6 +275,9 @@ final class WallpaperEngineXBridge: ObservableObject {
 
     /// 正在设置壁纸中（防止 `restoreIfNeeded` 等场景重复调用 `setWallpaper`）
     private(set) var isSettingWallpaper = false
+    /// `isSettingWallpaper` 只保护 renderer 切换命令阶段；命令发出后，较慢的
+    /// 首帧/锁屏同步允许在后台收尾。generation 防止旧收尾覆盖更新的切换。
+    private var wallpaperSwitchGeneration: UInt64 = 0
 
     // MARK: - 持久化状态
 
@@ -334,6 +344,10 @@ final class WallpaperEngineXBridge: ObservableObject {
             self.handleCropDidChange(note)
         }
         .store(in: &self.cancellables)
+
+        // 正常退出、崩溃或强制停止调试进程时，wallpaper-wgpu 可能被 reparent
+        // 到 launchd。它不属于本次运行，必须在任何恢复任务启动前移除。
+        terminateUntrackedDesktopRenderers(reason: "bridgeInitialization")
     }
 
     deinit {
@@ -379,6 +393,27 @@ final class WallpaperEngineXBridge: ObservableObject {
         isControllingExternalEngine && activeRenderKind == .scene
     }
 
+    /// 视频/照片请求一经接受，就作废仍在等待 assets/首帧的旧 Scene/Web 请求。
+    /// 当前真正可见的 renderer 仍保留到新内容 ready 后的黑场提交；这里只清除
+    /// 已脱离管理字典的孤儿进程，避免它在提交后重新盖回目标屏。
+    func prepareForNonExternalWallpaperSwitch(on screens: [NSScreen], reason: String) {
+        wallpaperSwitchGeneration &+= 1
+        bakedStaticUpdateGeneration &+= 1
+        let screenIDs = Set(screens.map(\.wallpaperScreenIdentifier))
+        let reaped = terminateUntrackedDesktopRenderers(
+            targetScreenIDs: screenIDs,
+            reason: reason
+        )
+        if isSettingWallpaper || !reaped.isEmpty {
+            AppLogger.error(.wallpaper, "Non-external wallpaper superseded pending renderer", metadata: [
+                "reason": reason,
+                "generation": wallpaperSwitchGeneration,
+                "isSettingWallpaper": isSettingWallpaper,
+                "reapedPIDs": reaped.map(String.init).joined(separator: ",")
+            ])
+        }
+    }
+
     // MARK: - 设置壁纸
 
     /// 使用 wallpaper-wgpu 设置动态壁纸
@@ -418,19 +453,43 @@ final class WallpaperEngineXBridge: ObservableObject {
             throw WallpaperEngineError.executionFailed("已有壁纸设置任务进行中，请稍后重试")
         }
         isSettingWallpaper = true
-        defer {
+        wallpaperSwitchGeneration &+= 1
+        let switchGeneration = wallpaperSwitchGeneration
+        var ownsSettingFlag = true
+        func releaseSettingFlag() {
+            guard ownsSettingFlag else { return }
+            ownsSettingFlag = false
             isSettingWallpaper = false
+        }
+        defer {
+            releaseSettingFlag()
             print("[WallpaperEngineXBridge] <<< setWallpaper END")
         }
 
+        let effectiveScreens: [NSScreen]
+        if let screens = targetScreens, !screens.isEmpty {
+            effectiveScreens = screens
+        } else {
+            effectiveScreens = NSScreen.screens
+        }
+        terminateUntrackedDesktopRenderers(
+            targetScreenIDs: Set(effectiveScreens.map(\.wallpaperScreenIdentifier)),
+            reason: "setWallpaper"
+        )
+        let preservesStaticOverlayUntilReady = StaticImageWallpaperOverlayManager.shared
+            .hasActiveWallpaper(on: effectiveScreens)
+
         // 设场景/web 壁纸时只清理目标屏的静态图 overlay。单屏自动轮换不能
         // 误删其他显示器在“系统壁纸同步关闭”时维护的独立静态图。
-        if let screens = targetScreens, !screens.isEmpty {
-            for screen in screens {
-                StaticImageWallpaperOverlayManager.shared.clearState(for: screen)
+        // 有可见 overlay 时延后到新内容 ready 后的黑场内清理。
+        if !preservesStaticOverlayUntilReady {
+            if let screens = targetScreens, !screens.isEmpty {
+                for screen in screens {
+                    StaticImageWallpaperOverlayManager.shared.clearState(for: screen)
+                }
+            } else {
+                StaticImageWallpaperOverlayManager.shared.clearState()
             }
-        } else {
-            StaticImageWallpaperOverlayManager.shared.clearState()
         }
 
 	// 壁纸切换时使设计面板的缓存失效
@@ -439,15 +498,33 @@ final class WallpaperEngineXBridge: ObservableObject {
 	let resolvedPath = WorkshopService.resolveWallpaperEngineProjectRoot(startingAt: URL(fileURLWithPath: path)).path
 	let renderKind: RenderKind = isWebWallpaper(path: resolvedPath) ? .web : .scene
 
-        print("[WallpaperEngineXBridge] step 1: 停止本机视频层")
+        // 跨类型切换不能先拆视频窗。先让 Scene/Web 在旧视频后方完整加载，
+        // 最后才在短黑场内提交并释放旧解码器。
+        let preservesNativeVideoUntilReady = VideoWallpaperManager.shared
+            .hasNativeVideoWallpaper(on: effectiveScreens)
+        let preservesOldWallpaperUntilReady = preservesNativeVideoUntilReady || preservesStaticOverlayUntilReady
+        let oldWallpaperPresentationHold: Task<Void, Never>? = preservesOldWallpaperUntilReady
+            ? Task { @MainActor in
+                while !Task.isCancelled {
+                    VideoWallpaperManager.shared.keepNativeVideoPresentationFront(on: effectiveScreens)
+                    StaticImageWallpaperOverlayManager.shared.keepPresentationFront(on: effectiveScreens)
+                    try? await Task.sleep(nanoseconds: 50_000_000)
+                }
+            }
+            : nil
+        defer { oldWallpaperPresentationHold?.cancel() }
 
-        // 1. 只停本机视频层；切勿调用 `VideoWallpaperManager.stopWallpaper()`（会恢复静态桌面）
-        if let screens = targetScreens, !screens.isEmpty {
-            for screen in screens {
-                VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly(for: screen)
+        if !preservesNativeVideoUntilReady {
+            print("[WallpaperEngineXBridge] step 1: 无旧视频需要保留，清理本机视频层")
+            if let screens = targetScreens, !screens.isEmpty {
+                for screen in screens {
+                    VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly(for: screen)
+                }
+            } else {
+                VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly()
             }
         } else {
-            VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly()
+            print("[WallpaperEngineXBridge] step 1: 保留旧视频，等待 \(renderKind.rawValue) 首帧就绪")
         }
 
         // macOS 26+：清空旧的锁屏镜像帧源缓存。
@@ -464,14 +541,16 @@ final class WallpaperEngineXBridge: ObservableObject {
         if #available(macOS 26.0, *) {
             LockScreenWallpaperService.shared.clearRealtimeSourceIfNeeded(notify: renderKind != .web)
         }
-        let effectiveScreens: [NSScreen]
-        if let screens = targetScreens, !screens.isEmpty {
-            effectiveScreens = screens
-        } else {
-            effectiveScreens = NSScreen.screens
-        }
         let effectiveScreenIDs = Set(effectiveScreens.map(\.wallpaperScreenIdentifier))
         // 新壁纸接管目标屏幕后，旧的自动按屏暂停状态不应泄漏到新进程。
+        // 仅清 Set 不够：Scene 进程可能仍处于真实的 SIGSTOP(T) 状态，无法读取
+        // wallpaper-control 热切换文件，也无法处理稍后的 SIGTERM。切换开始时必须
+        // 先 SIGCONT；完成后 AutoPauseManager 会按当前前台状态重新评估。
+        for screen in effectiveScreens {
+            if let info = screenProcesses[screen.wallpaperScreenIdentifier] {
+                kill(info.pid, SIGCONT)
+            }
+        }
         perScreenPausedScreenIDs.subtract(effectiveScreenIDs)
         updateExternalPausedStateFromPerScreenPauses()
 
@@ -494,6 +573,7 @@ final class WallpaperEngineXBridge: ObservableObject {
                    status != 0 {
                     print("[WallpaperEngineXBridge] ⚠️ 按屏停止 Web 壁纸失败 screen=\(screenIdx) exit=\(status)")
                 }
+                guard wallpaperSwitchGeneration == switchGeneration else { return }
             }
             webRenderer.stop()
             for state in targetWebStates {
@@ -509,13 +589,35 @@ final class WallpaperEngineXBridge: ObservableObject {
                 print("[WallpaperEngineXBridge] 切换到 Web 壁纸，清理目标屏幕 \(sceneScreenIDsToStop.count) 个 scene 渲染进程")
                 for screenID in sceneScreenIDsToStop {
                     await stopScreenProcess(screenID)
+                    guard wallpaperSwitchGeneration == switchGeneration else { return }
                 }
             }
         }
 
         if renderKind == .web {
-            try await setWebWallpaper(path: resolvedPath, targetScreens: targetScreens)
-            recordRenderState(path: resolvedPath, renderKind: renderKind, screens: effectiveScreens, userProperties: userProperties)
+            try await setWebWallpaper(
+                path: resolvedPath,
+                targetScreens: targetScreens,
+                switchGeneration: switchGeneration,
+                onRendererSwitched: {
+                    // 先发布新的管理状态，再释放设置标志；紧接着发生的视频/
+                    // Scene 切换才能准确识别并停止刚启动的 Web renderer。
+                    recordRenderState(
+                        path: resolvedPath,
+                        renderKind: renderKind,
+                        screens: effectiveScreens,
+                        userProperties: userProperties
+                    )
+                    releaseSettingFlag()
+                }
+            )
+            // Web 的锁屏帧同步可能比下一次用户切换更晚结束。旧 generation
+            // 到这里时直接退出，不能重新写回 render state 或提交旧黑场。
+            guard wallpaperSwitchGeneration == switchGeneration else { return }
+            if preservesOldWallpaperUntilReady {
+                oldWallpaperPresentationHold?.cancel()
+                await commitPreparedRendererOverNativeVideo(on: effectiveScreens)
+            }
             DynamicWallpaperAutoPauseManager.shared.clearForegroundPauseForWallpaperSwitch()
             DynamicWallpaperAutoPauseManager.shared.reevaluateCurrentState()
             ensureAudioRelayMatchesActiveWallpaper(projectRoot: resolvedPath)
@@ -533,6 +635,15 @@ final class WallpaperEngineXBridge: ObservableObject {
         } else {
             resolvedAssets = ""
             AppLogger.error(.wallpaper, "内嵌 assets 解压失败或超时，wallpaper-wgpu 可能无法正常渲染")
+        }
+        guard wallpaperSwitchGeneration == switchGeneration else {
+            AppLogger.error(.wallpaper, "setWallpaper 在 renderer 启动前已被新请求取代", metadata: [
+                "path": resolvedPath,
+                "stage": "assetsReady",
+                "generation": switchGeneration,
+                "currentGeneration": wallpaperSwitchGeneration
+            ])
+            return
         }
 
         // 4. 准备 wallpaper-wgpu 二进制路径
@@ -581,6 +692,7 @@ final class WallpaperEngineXBridge: ObservableObject {
         var lastLaunchError: Error?
 
         for screen in effectiveScreens {
+            guard wallpaperSwitchGeneration == switchGeneration else { return }
             let f = screen.frame
             let scale = screen.backingScaleFactor
             let screenX = Int(f.origin.x.rounded())
@@ -725,6 +837,7 @@ final class WallpaperEngineXBridge: ObservableObject {
 
             if screenProcesses[screenID] != nil {
                 await stopScreenProcess(screenID)
+                guard wallpaperSwitchGeneration == switchGeneration else { return }
             }
 
             var perScreenArgs = baseArgs
@@ -870,6 +983,30 @@ final class WallpaperEngineXBridge: ObservableObject {
         if effectiveScreens.count > 1 {
             print("[WallpaperEngineXBridge] 多显示器模式: \(effectiveScreens.count) 个屏幕")
         }
+
+        // renderer 已完成热切换或进程启动，此时立刻释放设置标志。首帧稳定等待
+        // 只是过渡收尾，不应阻止用户继续切换 Scene/Web/视频。
+        releaseSettingFlag()
+        guard wallpaperSwitchGeneration == switchGeneration else { return }
+
+        if preservesOldWallpaperUntilReady {
+            do {
+                try await waitForScenePresentationReady(path: resolvedPath, screens: effectiveScreens)
+            } catch {
+                guard wallpaperSwitchGeneration == switchGeneration else { return }
+                // 新 Scene 没有形成稳定首帧时继续保留旧视频，并清掉藏在后方的
+                // 半初始化 renderer，避免下一次设置误把它当作可热切换的活跃场景。
+                for screen in effectiveScreens {
+                    await stopScreenProcess(screen.wallpaperScreenIdentifier)
+                }
+                throw error
+            }
+            guard wallpaperSwitchGeneration == switchGeneration else { return }
+            oldWallpaperPresentationHold?.cancel()
+            await commitPreparedRendererOverNativeVideo(on: effectiveScreens)
+        }
+
+        guard wallpaperSwitchGeneration == switchGeneration else { return }
 
         updateControlStateFromScreenStates(preferredPath: resolvedPath, preferredKind: renderKind)
         persistState()
@@ -1488,6 +1625,7 @@ final class WallpaperEngineXBridge: ObservableObject {
         let processCount = screenProcesses.count
         AppLogger.error(.wallpaper, "ensureStoppedForNonCLIWallpaper(全局)", metadata: ["processCount": processCount])
         print("[WallpaperEngineXBridge] ensureStoppedForNonCLIWallpaper: 开始清理 \(processCount) 个渲染进程")
+        terminateUntrackedDesktopRenderers(reason: "ensureStoppedGlobal")
         if #available(macOS 26.0, *) {
             LockScreenWallpaperService.shared.clearRealtimeSourceIfNeeded()
         }
@@ -1525,6 +1663,10 @@ final class WallpaperEngineXBridge: ObservableObject {
         }
 
         let screenID = targetScreen.wallpaperScreenIdentifier
+        terminateUntrackedDesktopRenderers(
+            targetScreenIDs: Set([screenID]),
+            reason: "ensureStoppedForScreen"
+        )
         guard isManaging(screen: targetScreen) else {
             AppLogger.error(.wallpaper, "ensureStoppedForNonCLIWallpaper(for:): 屏幕不受外部引擎管理，跳过", metadata: ["screenID": screenID])
             return
@@ -1581,14 +1723,84 @@ final class WallpaperEngineXBridge: ObservableObject {
         persistState()
     }
 
+    /// 黑场交接专用：Web renderer 必须确认 stop-screen IPC 已完成后才能揭开
+    /// 新壁纸。普通同步入口为了兼容旧调用仍是 fire-and-forget；过渡路径不能用它，
+    /// 否则黑场退去时旧 WKWebView 仍可能盖在新视频/照片上。
+    func ensureStoppedForNonCLIWallpaperForTransition(for targetScreen: NSScreen) async {
+        let screenID = targetScreen.wallpaperScreenIdentifier
+        terminateUntrackedDesktopRenderers(
+            targetScreenIDs: Set([screenID]),
+            reason: "crossTypeTransition"
+        )
+        guard isManaging(screen: targetScreen) else { return }
+
+        let targetState = renderState(for: targetScreen)
+        if targetState?.renderKind == .web || (targetState == nil && activeRenderKind == .web) {
+            webRenderer.stop()
+            if let screenIndex = Self.legacyCLIScreenIndex(for: targetScreen) {
+                do {
+                    let status = try await Self.runLegacyCLIClientCommand([
+                        "stop-screen",
+                        String(screenIndex)
+                    ])
+                    if status != 0 {
+                        print("[WallpaperEngineXBridge] ⚠️ 黑场交接 stop-screen 失败 screen=\(screenIndex) exit=\(status)")
+                    }
+                } catch {
+                    print("[WallpaperEngineXBridge] ⚠️ 黑场交接 stop-screen 异常: \(error.localizedDescription)")
+                }
+            }
+        }
+
+        // IPC 已返回后直接清理本地管理状态和可能存在的 Scene 进程。
+        // 不再调用同步版本：它会再次异步发送 stop-screen，最后一块 Web 屏退出时
+        // 甚至可能重新拉起 daemon client，造成旧窗口重新排到新壁纸前面。
+        if #available(macOS 26.0, *) {
+            LockScreenWallpaperService.shared.clearRealtimeSourceIfNeeded()
+        }
+        if let info = screenProcesses[screenID] {
+            screenWatchdogs[info.pid]?.cancel()
+            screenWatchdogs.removeValue(forKey: info.pid)
+            killAllAudioChildren(pid: info.pid)
+            perScreenPausedScreenIDs.remove(screenID)
+            terminateRenderer(pid: info.pid)
+            let pid = info.pid
+            // Scene 进程可能刚从 SIGSTOP 恢复。黑场必须等它的窗口真正退出，
+            // 不能像普通清理那样安排一个 2 秒后的 watchdog 就立刻揭开。
+            let gracefulDeadline = Date().addingTimeInterval(0.45)
+            while kill(pid, 0) == 0 && Date() < gracefulDeadline {
+                try? await Task.sleep(nanoseconds: 20_000_000)
+            }
+            if kill(pid, 0) == 0 {
+                kill(pid, SIGKILL)
+                let killDeadline = Date().addingTimeInterval(0.30)
+                while kill(pid, 0) == 0 && Date() < killDeadline {
+                    try? await Task.sleep(nanoseconds: 20_000_000)
+                }
+            }
+            removeScreenProcess(screenID)
+            _deinitPIDs.remove(pid)
+        }
+        removeRenderState(for: targetScreen)
+        perScreenPausedScreenIDs.remove(screenID)
+        updateControlStateFromScreenStates()
+        ensureAudioRelayMatchesActiveWallpaper()
+        persistState()
+    }
+
     /// 应用退出前调用：立即杀死所有渲染进程，不等待退出，避免阻塞主线程导致 App 卡死。
     func prepareForAppTermination() {
-        let processCount = screenProcesses.count
-        let pids = screenProcesses.values.map { "\($0.pid)" }.joined(separator: ", ")
+        // `stopScreenProcess` 会先移除字典记录，再等待 watchdog。若用户恰好在
+        // 这段窗口退出 App，只遍历 screenProcesses 会漏掉仍活着的子进程。
+        let discoveredPIDs = Set(Self.discoverDesktopRenderers().map(\.pid))
+        let pidsToKill = discoveredPIDs.union(screenProcesses.values.map(\.pid))
+        let processCount = pidsToKill.count
+        let pids = pidsToKill.map(String.init).joined(separator: ", ")
         print("[WallpaperEngineXBridge] prepareForAppTermination: 应用退出，立即终止 \(processCount) 个渲染进程 pids=[\(pids)]")
         // 直接 SIGKILL 所有屏幕渲染进程，不做 graceful terminate + 等待
-        for (_, info) in screenProcesses {
-            kill(info.pid, SIGKILL)
+        for pid in pidsToKill {
+            kill(pid, SIGCONT)
+            kill(pid, SIGKILL)
         }
         // 同步杀掉旧 CLI daemon
         Self.killLegacyDaemonSync()
@@ -1657,7 +1869,57 @@ final class WallpaperEngineXBridge: ObservableObject {
         try? FileManager.default.removeItem(atPath: pidPath)
     }
 
-    private func setWebWallpaper(path: String, targetScreens: [NSScreen]?) async throws {
+    /// Scene renderer writes canvas-size after the current project has initialized.
+    /// WindowServer does not reliably expose backing-store metadata for desktop-level
+    /// windows, so readiness must not depend on CGWindowList (that can hold the whole
+    /// wallpaper switch busy until timeout). Require the new canvas generation and a
+    /// live process to remain stable briefly, then leave several display intervals for
+    /// the first drawable before entering the black commit.
+    private func waitForScenePresentationReady(path: String, screens: [NSScreen]) async throws {
+        let expectedPath = URL(fileURLWithPath: path).standardizedFileURL.path
+        let deadline = Date().addingTimeInterval(10)
+        var stableSince: Date?
+        while Date() < deadline {
+            let allReady = screens.allSatisfy { screen in
+                let screenID = screen.wallpaperScreenIdentifier
+                guard let state = screenRenderStates[screenID],
+                      URL(fileURLWithPath: state.path).standardizedFileURL.path == expectedPath,
+                      let process = screenProcesses[screenID],
+                      process.process.isRunning,
+                      let canvasURL = process.canvasSizeURL else { return false }
+                return readCanvasSize(url: canvasURL) != nil
+            }
+            if allReady {
+                if stableSince == nil {
+                    stableSince = Date()
+                } else if Date().timeIntervalSince(stableSince!) >= 0.24 {
+                    // The old video remains in front during this settle period.
+                    try? await Task.sleep(nanoseconds: 160_000_000)
+                    return
+                }
+            } else {
+                stableSince = nil
+            }
+            try await Task.sleep(nanoseconds: 80_000_000)
+        }
+        throw WallpaperEngineError.executionFailed("Scene 实时渲染首帧准备超时，已保留原视频壁纸")
+    }
+
+    private func commitPreparedRendererOverNativeVideo(on screens: [NSScreen]) async {
+        await WallpaperCrossTypeTransitionCoordinator.shared.commitPreparedContent(on: screens) {
+            for screen in screens {
+                VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly(for: screen)
+                StaticImageWallpaperOverlayManager.shared.clearState(for: screen)
+            }
+        }
+    }
+
+    private func setWebWallpaper(
+        path: String,
+        targetScreens: [NSScreen]?,
+        switchGeneration: UInt64,
+        onRendererSwitched: @MainActor () -> Void
+    ) async throws {
         let screens = targetScreens?.isEmpty == false ? targetScreens! : NSScreen.screens
         guard !screens.isEmpty else {
             throw WallpaperEngineError.executionFailed("没有可用的 Web 壁纸目标显示器")
@@ -1689,9 +1951,15 @@ final class WallpaperEngineXBridge: ObservableObject {
             }
         }
 
+        // daemon 已接受所有目标屏的 set 命令；从这里开始的属性初始化和锁屏
+        // 静态帧同步不再占用全局“正在设置”标志。
+        onRendererSwitched()
+        guard wallpaperSwitchGeneration == switchGeneration else { return }
+
         if let propertiesJSON = try? WebWallpaperDesignService.shared.effectivePropertiesJSON(for: path),
            !propertiesJSON.isEmpty {
             for screenIndex in targetIndexes {
+                guard wallpaperSwitchGeneration == switchGeneration else { return }
                 let status = try await Self.runLegacyCLIClientCommand([
                     "apply-properties",
                     propertiesJSON,
@@ -1703,8 +1971,11 @@ final class WallpaperEngineXBridge: ObservableObject {
             }
         }
 
+        guard wallpaperSwitchGeneration == switchGeneration else { return }
         let captureURLs = await captureWebFallbackFramesForLockScreenIfNeeded(targetScreens: targetScreens)
+        guard wallpaperSwitchGeneration == switchGeneration else { return }
         await syncWebStaticFramesToLockScreenIfNeeded(imageURLs: captureURLs, targetScreens: targetScreens)
+        guard wallpaperSwitchGeneration == switchGeneration else { return }
 
         // 初始化 Web 壁纸的音频状态（同步当前 mute/volume）
         let isMuted = VideoWallpaperManager.shared.isMuted
@@ -1967,7 +2238,99 @@ final class WallpaperEngineXBridge: ObservableObject {
     // MARK: - 进程生命周期管理
 
     private func terminateRenderer(pid: pid_t) {
+        // SIGTERM sent to a SIGSTOP'ed renderer remains pending and its desktop
+        // window stays visible. SIGCONT is harmless for a running process and makes
+        // termination deterministic for auto-paused Scene wallpapers.
+        kill(pid, SIGCONT)
         kill(pid, SIGTERM)
+    }
+
+    /// 只识别带 WaifuX wallpaper-control 文件的桌面 Scene 进程，避免误伤
+    /// SceneOfflineBake/BakeService 启动的离线渲染任务。
+    private nonisolated static func discoverDesktopRenderers() -> [DiscoveredDesktopRenderer] {
+        let process = Process()
+        let pipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/ps")
+        process.arguments = ["-axo", "pid=,ppid=,command="]
+        process.standardOutput = pipe
+        process.standardError = FileHandle.nullDevice
+
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        guard let output = String(data: data, encoding: .utf8) else { return [] }
+
+        return output.split(separator: "\n").compactMap { line in
+            let columns = line.split(
+                maxSplits: 2,
+                omittingEmptySubsequences: true,
+                whereSeparator: { $0 == " " || $0 == "\t" }
+            )
+            guard columns.count == 3,
+                  let pid = pid_t(columns[0]),
+                  let parentPID = pid_t(columns[1]),
+                  pid > 0 else {
+                return nil
+            }
+            let command = String(columns[2])
+            guard command.contains("/wallpaper-wgpu "),
+                  command.contains(" --wallpaper-control "),
+                  command.contains("waifux-wallpaper-wgpu-wallpaper-") else {
+                return nil
+            }
+            return DiscoveredDesktopRenderer(
+                pid: pid,
+                parentPID: parentPID,
+                command: command
+            )
+        }
+    }
+
+    private static func rendererControlMarker(for screenID: String) -> String {
+        let safeID = screenID.map { ch -> Character in
+            ch.isLetter || ch.isNumber || ch == "-" || ch == "_" ? ch : "_"
+        }
+        return "waifux-wallpaper-wgpu-wallpaper-\(String(safeID))-"
+    }
+
+    /// 清除不在当前 `screenProcesses` 登记中的桌面 renderer。先 SIGCONT 是为
+    /// 了解除自动暂停留下的 SIGSTOP；孤儿没有任何状态需要保存，随后直接
+    /// SIGKILL，确保它的窗口在新壁纸揭开前从 WindowServer 消失。
+    @discardableResult
+    private func terminateUntrackedDesktopRenderers(
+        targetScreenIDs: Set<String>? = nil,
+        reason: String
+    ) -> [pid_t] {
+        let managedPIDs = Set(screenProcesses.values.map(\.pid))
+        let targetMarkers = targetScreenIDs.map { ids in
+            ids.map(Self.rendererControlMarker(for:))
+        }
+        let candidates = Self.discoverDesktopRenderers().filter { renderer in
+            guard !managedPIDs.contains(renderer.pid) else { return false }
+            guard let targetMarkers else { return true }
+            return targetMarkers.contains { renderer.command.contains($0) }
+        }
+        guard !candidates.isEmpty else { return [] }
+
+        for renderer in candidates {
+            kill(renderer.pid, SIGCONT)
+            kill(renderer.pid, SIGTERM)
+            if kill(renderer.pid, 0) == 0 {
+                kill(renderer.pid, SIGKILL)
+            }
+        }
+        let pids = candidates.map(\.pid)
+        AppLogger.error(.wallpaper, "Reaped untracked wallpaper-wgpu desktop renderers", metadata: [
+            "reason": reason,
+            "pids": pids.map(String.init).joined(separator: ","),
+            "parents": candidates.map { "\($0.pid):\($0.parentPID)" }.joined(separator: ","),
+            "targets": targetScreenIDs?.sorted().joined(separator: ",") ?? "all"
+        ])
+        return pids
     }
 
     /// 终止 wallpaper-wgpu 渲染器启动的 afplay 子进程（音频播放）。
@@ -2252,6 +2615,13 @@ final class WallpaperEngineXBridge: ObservableObject {
                     print("[WallpaperEngineXBridge] 未找到持久化目标显示器，跳过恢复: \(state.screenID)")
                     continue
                 }
+                guard !VideoWallpaperManager.shared.hasActiveWallpaper(on: screen) else {
+                    AppLogger.error(.wallpaper, "跳过已被视频接管屏幕的 Scene/Web 恢复", metadata: [
+                        "screenID": screen.wallpaperScreenIdentifier,
+                        "path": state.path
+                    ])
+                    continue
+                }
                 let userProps = state.userProperties ?? SceneWallpaperPropertiesService.propertiesOverrideJSON(for: state.path)
                 try? await setWallpaper(path: state.path, targetScreens: [screen], userProperties: userProps)
             }
@@ -2281,10 +2651,16 @@ final class WallpaperEngineXBridge: ObservableObject {
         }
 
         let hasPersistedTargets = !targetScreenIDs.isEmpty || !targetScreenFingerprints.isEmpty
-        let screens = hasPersistedTargets ? activeTargetScreens() : []
+        let screens = (hasPersistedTargets ? activeTargetScreens() : NSScreen.screens).filter {
+            !VideoWallpaperManager.shared.hasActiveWallpaper(on: $0)
+        }
+        guard !screens.isEmpty else {
+            AppLogger.error(.wallpaper, "跳过 Scene/Web 恢复：目标屏幕已有视频运行")
+            return
+        }
         // 恢复用户属性覆盖
         let userProps = SceneWallpaperPropertiesService.propertiesOverrideJSON(for: path)
-        try? await setWallpaper(path: path, targetScreens: hasPersistedTargets && !screens.isEmpty ? screens : nil, userProperties: userProps)
+        try? await setWallpaper(path: path, targetScreens: screens, userProperties: userProps)
     }
 
     // MARK: - 持久化
@@ -2630,6 +3006,36 @@ final class WallpaperEngineXBridge: ObservableObject {
         screenRenderStates.values.contains { $0.screenFingerprint == screen.wallpaperScreenFingerprint } ||
         targetScreenIDs.contains(screen.wallpaperScreenIdentifier) ||
         targetScreenFingerprints.contains(screen.wallpaperScreenFingerprint)
+    }
+
+    /// 过渡预热只应保留当前真正可见的 renderer，不能把用于重启恢复的持久化
+    /// target/render state 当作活跃窗口。Scene 进程退出后状态可能短暂滞留；若仍
+    /// 按跨类型处理，新视频的黑色预热窗会直接暴露在桌面上，看起来像长黑场。
+    func hasLivePresentation(on screen: NSScreen) -> Bool {
+        processPendingTermination()
+        let state = renderState(for: screen)
+        if state?.renderKind == .web {
+            return isControllingExternalEngine
+                && activeRenderKind == .web
+                && Self.isLegacyDaemonRunning
+        }
+
+        let screenID = screen.wallpaperScreenIdentifier
+        let processInfo = screenProcesses[screenID]
+            ?? state.flatMap { screenProcesses[$0.screenID] }
+        guard let processInfo else { return false }
+        return processInfo.process.isRunning && kill(processInfo.pid, 0) == 0
+    }
+
+    /// Web 的管理状态会持久化用于启动恢复，不能单靠它判断桌面上是否仍有窗口。
+    /// daemon PID 不存在时应按“无旧 renderer”处理，否则新视频会误走跨类型预热，
+    /// 将尚未提交的黑色窗口直接留在桌面上。
+    private static var isLegacyDaemonRunning: Bool {
+        let pidPath = "/tmp/wallpaperengine-cli.pid"
+        guard let pidText = try? String(contentsOfFile: pidPath, encoding: .utf8),
+              let pid = pid_t(pidText.trimmingCharacters(in: .whitespacesAndNewlines)),
+              pid > 0 else { return false }
+        return kill(pid, 0) == 0
     }
 
     /// 该屏的外部引擎是否为 web 壁纸（web 暂不支持可视区域调节）。

--- a/Services/WallpaperSchedulerService.swift
+++ b/Services/WallpaperSchedulerService.swift
@@ -2095,7 +2095,7 @@ class WallpaperSchedulerService: ObservableObject {
                 // 不得反向替换桌面实时渲染——否则轮播第二次起会变成播放固定时长的
                 // 烘焙视频而非 wallpaper-wgpu 实时渲染。
                 // on-end 模式下：如果设置了 webSceneSwitchSeconds（走定时器），允许实时渲染。
-                let isRealtimeRenderingEnabled = UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled")
+                let isRealtimeRenderingEnabled = UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true
                 let preferRealtimeForScene = isRealtimeRenderingEnabled && (!onEndMode || webSceneSwitchEnabled)
                 var bakedVideoPath: String? = nil
                 var sceneBakeItemID: String? = nil

--- a/ViewModels/MediaExploreViewModel.swift
+++ b/ViewModels/MediaExploreViewModel.swift
@@ -1134,6 +1134,7 @@ final class MediaExploreViewModel: ObservableObject {
                 posterURL: posterURL,
                 muted: muted,
                 targetScreens: resolvedTargetScreens,
+                animatedTransition: true,
                 usesSharedVideoDecoder: usesSharedVideoDecoder
             )
             return
@@ -1151,6 +1152,7 @@ final class MediaExploreViewModel: ObservableObject {
                     posterURL: posterURL,
                     muted: muted,
                     targetScreens: resolvedTargetScreens,
+                    animatedTransition: true,
                     usesSharedVideoDecoder: usesSharedVideoDecoder
                 )
                 return
@@ -1171,6 +1173,7 @@ final class MediaExploreViewModel: ObservableObject {
             posterURL: posterURL,
             muted: muted,
             targetScreens: resolvedTargetScreens,
+            animatedTransition: true,
             usesSharedVideoDecoder: usesSharedVideoDecoder
         )
     }

--- a/ViewModels/WallpaperViewModel.swift
+++ b/ViewModels/WallpaperViewModel.swift
@@ -1701,9 +1701,18 @@ class WallpaperViewModel: ObservableObject {
             from: imageURL,
             for: screens
         )
+        WallpaperEngineXBridge.shared.prepareForNonExternalWallpaperSwitch(
+            on: screens,
+            reason: "applyStaticWallpaper"
+        )
 
-        WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaper()
-        VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly()
+        let preservesDynamicWallpaperUntilReady = VideoWallpaperManager.shared
+            .hasNativeVideoWallpaper(on: screens)
+            || screens.contains { WallpaperEngineXBridge.shared.isManaging(screen: $0) }
+        if !preservesDynamicWallpaperUntilReady {
+            WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaper()
+            VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly()
+        }
 
         // macOS 26+：仅当用户未启用动态锁屏时才清空锁屏扩展状态。
         // 使用持久化设置 isLockScreenEnabled 而非 isLockScreenMirroringActive。
@@ -1737,6 +1746,10 @@ class WallpaperViewModel: ObservableObject {
             // 互斥：清除可能残留的静态图 overlay
             StaticImageWallpaperOverlayManager.shared.clearState()
             print("[WallpaperViewModel] 🔒 动态锁屏已启用，已将静态图同步到 WaifuX 锁屏/桌面实例")
+            await finishStaticWallpaperTransitionIfNeeded(
+                screens: screens,
+                preservesDynamicWallpaperUntilReady: preservesDynamicWallpaperUntilReady
+            )
             return
         }
 
@@ -1755,6 +1768,10 @@ class WallpaperViewModel: ObservableObject {
                 )
             }
             StaticWallpaperGrainManager.shared.updateOverlay()
+            await finishStaticWallpaperTransitionIfNeeded(
+                screens: screens,
+                preservesDynamicWallpaperUntilReady: preservesDynamicWallpaperUntilReady
+            )
             return
         }
 
@@ -1776,6 +1793,10 @@ class WallpaperViewModel: ObservableObject {
 
         // 更新静态壁纸颗粒蒙层（独立窗口，不受壁纸切换影响）
         StaticWallpaperGrainManager.shared.updateOverlay()
+        await finishStaticWallpaperTransitionIfNeeded(
+            screens: screens,
+            preservesDynamicWallpaperUntilReady: preservesDynamicWallpaperUntilReady
+        )
     }
 
     // MARK: - 设置壁纸到指定屏幕
@@ -1790,13 +1811,23 @@ class WallpaperViewModel: ObservableObject {
                 from: imageURL,
                 for: targetScreen
             )
+            WallpaperEngineXBridge.shared.prepareForNonExternalWallpaperSwitch(
+                on: [targetScreen],
+                reason: "applyStaticWallpaperForScreen"
+            )
+
+            let preservesDynamicWallpaperUntilReady = VideoWallpaperManager.shared
+                .hasNativeVideoWallpaper(on: [targetScreen])
+                || WallpaperEngineXBridge.shared.isManaging(screen: targetScreen)
 
             // 切到静态图前如果目标屏幕被 CLI 管理则停 CLI 引擎
-            if WallpaperEngineXBridge.shared.isManaging(screen: targetScreen) {
-                WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaper(for: targetScreen)
+            if !preservesDynamicWallpaperUntilReady {
+                if WallpaperEngineXBridge.shared.isManaging(screen: targetScreen) {
+                    WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaper(for: targetScreen)
+                }
+                // 只停目标屏幕的动态壁纸，避免影响其他屏幕
+                VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly(for: targetScreen)
             }
-            // 只停目标屏幕的动态壁纸，避免影响其他屏幕
-            VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly(for: targetScreen)
             // macOS 26+：仅当用户未启用动态锁屏时才清空锁屏镜像帧源缓存。
             // 使用持久化设置 isLockScreenEnabled 而非 isLockScreenMirroringActive。
             let shouldClearExtension: Bool = {
@@ -1822,6 +1853,10 @@ class WallpaperViewModel: ObservableObject {
                     StaticImageWallpaperOverlayManager.shared.clearState()
                     print("[WallpaperViewModel] 🔒 动态锁屏已启用，已将单屏静态图同步到 WaifuX 实例")
                 }
+                await finishStaticWallpaperTransitionIfNeeded(
+                    screens: [targetScreen],
+                    preservesDynamicWallpaperUntilReady: preservesDynamicWallpaperUntilReady
+                )
                 return
             }
 
@@ -1834,6 +1869,10 @@ class WallpaperViewModel: ObservableObject {
                     for: targetScreen
                 )
                 StaticWallpaperGrainManager.shared.updateOverlay()
+                await finishStaticWallpaperTransitionIfNeeded(
+                    screens: [targetScreen],
+                    preservesDynamicWallpaperUntilReady: preservesDynamicWallpaperUntilReady
+                )
                 return
             }
 
@@ -1849,8 +1888,30 @@ class WallpaperViewModel: ObservableObject {
 
             // 互斥：走系统壁纸时关闭并清除静态图 overlay 持久化状态
             StaticImageWallpaperOverlayManager.shared.clearState()
+            await finishStaticWallpaperTransitionIfNeeded(
+                screens: [targetScreen],
+                preservesDynamicWallpaperUntilReady: preservesDynamicWallpaperUntilReady
+            )
         } else {
             try await setWallpaper(from: imageURL, option: option)
+        }
+    }
+
+    private func finishStaticWallpaperTransitionIfNeeded(
+        screens: [NSScreen],
+        preservesDynamicWallpaperUntilReady: Bool
+    ) async {
+        guard preservesDynamicWallpaperUntilReady else { return }
+        // 独立静态 overlay 与视频窗处于同一 desktop level。overlay 准备完成时
+        // 先把仍在播放的旧视频提回前方，避免新图片在黑场出现前闪一帧。
+        VideoWallpaperManager.shared.keepNativeVideoPresentationFront(on: screens)
+        await WallpaperCrossTypeTransitionCoordinator.shared.commitPreparedContent(on: screens) {
+            for screen in screens {
+                await WallpaperEngineXBridge.shared.ensureStoppedForNonCLIWallpaperForTransition(
+                    for: screen
+                )
+                VideoWallpaperManager.shared.stopNativeVideoWallpaperOnly(for: screen)
+            }
         }
     }
 

--- a/Views/MediaDetailSheet.swift
+++ b/Views/MediaDetailSheet.swift
@@ -1382,7 +1382,7 @@ struct MediaDetailSheet: View {
                     bakeProgress = 0
                     if shouldAutoApplyAfterBake {
                         // 实时渲染：桌面已由实时引擎渲染，不自动覆盖；仅缓存
-                        if UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled") {
+                        if UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true {
                             sceneBakeStatusFlash = t("sceneBake.cached")
                             print("[MediaDetailSheet] 实时渲染模式：烘焙完成，产物已缓存（锁屏/companion 由统一 apply 路径处理）")
                         } else if SceneOfflineBakeService.isUsableBakedVideo(at: videoURL) {
@@ -1457,7 +1457,7 @@ struct MediaDetailSheet: View {
                     bakeProgress = 0
                     if shouldAutoApplyAfterBake {
                         // 与 scene 一致：实时开着只缓存；非实时则应用烘焙循环视频
-                        if UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled") {
+                        if UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true {
                             sceneBakeStatusFlash = t("sceneBake.cached")
                             print("[MediaDetailSheet] 实时渲染模式：Web 烘焙完成，产物已缓存（不覆盖当前实时壁纸）")
                         } else if SceneOfflineBakeService.isUsableBakedVideo(at: videoURL) {
@@ -1503,7 +1503,7 @@ struct MediaDetailSheet: View {
                         ? NSScreen.screens
                         : selectedScreen.map { [$0] }
                     var options = LocalWallpaperApplyService.Options(
-                        animatedTransition: false,
+                        animatedTransition: true,
                         requirePlaybackEndSupport: false,
                         muted: isMuted,
                         fallbackPosterURL: preferredWorkshopPosterForVideo,
@@ -3170,7 +3170,7 @@ struct MediaDetailSheet: View {
     private func applyWorkshopWallpaperFromLocalURL(_ localURL: URL) {
         // 非实时 scene 且尚无烘焙产物：保留详情页「先烘再设」流程（会阻塞生成 MP4）
         let contentRoot = sceneEngineContentRoot(for: localURL)
-        let isRealtime = UserDefaults.standard.bool(forKey: "scene_realtime_rendering_enabled")
+        let isRealtime = UserDefaults.standard.object(forKey: "scene_realtime_rendering_enabled") as? Bool ?? true
         let hasUsableBake = SceneOfflineBakeService.usableArtifact(from: currentDownloadRecord) != nil
         let projectType = Self.projectTypeString(at: contentRoot)
         if projectType == "scene", !isRealtime, !hasUsableBake {
@@ -3193,7 +3193,7 @@ struct MediaDetailSheet: View {
                         ? NSScreen.screens
                         : selectedScreen.map { [$0] }
                     var options = LocalWallpaperApplyService.Options(
-                        animatedTransition: false,
+                        animatedTransition: true,
                         requirePlaybackEndSupport: false,
                         muted: isMuted,
                         fallbackPosterURL: preferredWorkshopPosterForVideo,


### PR DESCRIPTION
## Summary\n\n- Keep one shared AVQueuePlayer/AVPlayerLooper for identical videos across displays.\n- Start playback immediately after the leader reaches its first frame.\n- Attach follower displays sequentially only after playback advances, including global black-scene transitions.\n\n## Validation\n\n- xcodebuild Debug build succeeded.\n- git diff --check passed.