### PR TITLE
fix: 修复 SIGSTOP 竞争条件导致 Scene/Web 壁纸切换后冻结

### DIFF
--- a/Services/DynamicWallpaperAutoPauseManager.swift
+++ b/Services/DynamicWallpaperAutoPauseManager.swift
@@ -446,6 +446,11 @@ final class DynamicWallpaperAutoPauseManager {
             for screenID in pausedIDs where weBridge.isManaging(screenID: screenID) {
                 weBridge.resumeWallpaper(for: screenID)
             }
+            // FIX: 确保全局恢复。per-screen resume 可能无法清除 isExternalPaused 全局标志，
+            // 导致新壁纸仍被视为处于暂停状态。
+            if weBridge.isExternalPaused {
+                weBridge.resumeWallpaper()
+            }
         }
 
         let videoManager = VideoWallpaperManager.shared

--- a/Services/WallpaperEngineXBridge.swift
+++ b/Services/WallpaperEngineXBridge.swift
@@ -648,7 +648,10 @@ final class WallpaperEngineXBridge: ObservableObject {
             }
         }
         perScreenPausedScreenIDs.subtract(effectiveScreenIDs)
-        updateExternalPausedStateFromPerScreenPauses()
+        // FIX: 壁纸切换时强制恢复全局暂停状态。如果 isExternalPaused 仍为 true，
+        // 新启动的 wallpaper-wgpu 进程会收到 --paused 参数，导致启动即暂停。
+        isExternalPaused = false
+        updateRendererAudioControls(paused: false)
 
         let targetWebStates = screenRenderStates.values.filter { state in
             state.renderKind == .web && effectiveScreenIDs.contains(state.screenID)
@@ -1260,13 +1263,13 @@ final class WallpaperEngineXBridge: ObservableObject {
             wasMediaRelayActiveBeforePause = true
             stopMediaRelayIfActive()
         }
-        let generation = launchGeneration
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) { [weak self] in
-            guard let self, self.isExternalPaused, self.launchGeneration == generation else { return }
-            for (screenID, info) in self.screenProcesses {
-                kill(info.pid, SIGSTOP)
-                print("[WallpaperEngineXBridge] 暂停渲染 屏幕 \(screenID) (pid=\(info.pid))")
-            }
+        // FIX: 使用 PID 快照立即发送 SIGSTOP，避免与 setWallpaper 竞争导致新进程被误暂停。
+        // 原代码使用 asyncAfter(delay: 0.15) 延迟发送 SIGSTOP，如果在此期间 setWallpaper
+        // 启动了新进程，延迟闭包中的 self.screenProcesses 可能包含新进程，导致新进程被错误暂停。
+        let currentPIDs = screenProcesses.mapValues { $0.pid }
+        for (screenID, pid) in currentPIDs {
+            kill(pid, SIGSTOP)
+            print("[WallpaperEngineXBridge] 暂停渲染 屏幕 \(screenID) (pid=\(pid))")
         }
     }
 


### PR DESCRIPTION
## 来源

原 PR #81（fork，作者 3195701996-bit）因 fork 未开启 maintainer edits 无法直接更新分支，故将改动同步到最新 main 后在本仓库重开此 PR。提交以原作者署名（--author）保留归属。改动内容与原 PR 完全一致。

## 问题描述

Scene/Web 类型壁纸在暂停后切换时可能冻结：`wallpaper-wgpu` 进程被 `SIGSTOP` 后陷入不可恢复状态（`T`→`U`）。

## 根本原因

1. **`pauseWallpaper()` 竞争条件**：`asyncAfter(0.15s)` 延迟发送 `SIGSTOP`，若期间 `setWallpaper()` 启动了新进程，延迟闭包中的 `self.screenProcesses` 会包含新进程 → 新进程被错误暂停。
2. **`setWallpaper()` 未复位暂停标志**：`isExternalPaused` 泄漏为 true → 新进程收到 `--paused` 参数启动即暂停。

## 修复内容

- **`pauseWallpaper()`**：移除 `asyncAfter` 延迟，改用 PID 快照立即 `SIGSTOP`，避免与新进程启动竞争。
- **`setWallpaper()`**：`perScreenPausedScreenIDs.subtract` 后强制 `isExternalPaused = false` + `updateRendererAudioControls(paused: false)`，确保新进程不会以暂停状态启动。
- **`clearForegroundPauseForWallpaperSwitch()`**：per-screen resume 后若全局标志仍为 true，补一次 `resumeWallpaper()` 确保全局状态清除。

## 验证

- ✅ 基于最新 main（5fe75cc）应用，diff 与原 PR 一致
- ✅ `xcodebuild -scheme WaifuX -configuration Debug` 编译通过

## 测试建议

- 切换 Scene / Web / 视频动态壁纸验证竞争条件
- 前台应用切换触发的自动暂停/恢复
- 合盖唤醒后的壁纸恢复