### PR TITLE
fix: prevent orphaned video renderer windows

### DIFF
--- a/wallpaper-video-renderer.swift
+++ b/wallpaper-video-renderer.swift
@@ -1911,17 +1911,17 @@ private final class VideoRendererDaemon {
     private func installParentWatchdog(parentPID: pid_t?) {
         guard let parentPID, parentPID > 1 else { return }
 
-        let watchdog = DispatchSource.makeTimerSource(queue: .main)
+        // Must stay independent of AppKit/IPC work: a blocked main actor must
+        // not leave an orphaned desktop window behind after the parent exits.
+        let watchdog = DispatchSource.makeTimerSource(queue: .global(qos: .utility))
         watchdog.schedule(deadline: .now() + 0.5, repeating: 0.5, leeway: .milliseconds(100))
-        watchdog.setEventHandler { [weak self] in
-            guard let self else { return }
+        watchdog.setEventHandler {
             guard getppid() == parentPID, kill(parentPID, 0) == 0 else {
                 AppLogger.info(
                     .wallpaper,
                     "video-renderer 检测到主进程退出，自动关闭"
                 )
-                self.shutdownForParentLoss()
-                return
+                _exit(0)
             }
         }
         watchdog.resume()


### PR DESCRIPTION
## 问题

`wallpaper-video-renderer` 的父进程 watchdog 运行在主队列。当 IPC / AppKit 工作阻塞主线程时，watchdog 无法及时检测 WaifuX 已经退出，导致 renderer 进程和桌面窗口继续存活。后续再启动 renderer 时，新旧窗口叠加会出现虚影。

## 修复

- 将父进程 watchdog 移到独立 utility 队列，不再依赖主线程。
- 检测到父进程消失后直接退出 renderer，由系统回收 AppKit / AVFoundation 资源。
- 保持现有 `window.alphaValue = 0.99` 和渲染逻辑不变。

## 影响

WaifuX 退出后，即使 renderer 主线程正在阻塞，子进程也会在 watchdog 周期内退出，避免残留桌面窗口。

## 验证

- `xcodebuild -quiet -project WaifuX.xcodeproj -scheme WaifuX -configuration Debug -destination 'platform=macOS' -derivedDataPath build/DerivedData CODE_SIGNING_ALLOWED=NO build`
- 启动临时 renderer，结束其测试父进程；确认 renderer 在 1 秒内自动退出。
