### PR TITLE
fix: 换壁纸后恢复裁切，默认铺满居中对齐

### DIFF
--- a/Services/SceneConfigOverrideService.swift
+++ b/Services/SceneConfigOverrideService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreGraphics
 
 /// 场景配置覆盖键定义（对应 wallpaper-wgpu 的 __-prefixed 系统键）
 public enum SceneConfigOverrideKey: String, CaseIterable, Sendable {
@@ -262,6 +263,31 @@ enum SceneConfigOverrideService {
             }
         }
         return result
+    }
+
+    /// Scene 画布像素（`orthogonalprojection`，含用户覆盖的宽高）。
+    /// 给铺满裁切在 wgpu 写出 canvas-size 之前用，才能按真实比例居中 cover。
+    static func sceneOrthogonalSize(for wallpaperPath: String) -> CGSize? {
+        let overrides = loadOverrides(for: wallpaperPath)
+        var width: Double?
+        var height: Double?
+        if case .number(let value) = overrides[.orthoWidth] { width = value }
+        if case .number(let value) = overrides[.orthoHeight] { height = value }
+        if width == nil || height == nil, let general = loadSceneGeneralDict(for: wallpaperPath),
+           let ortho = general["orthogonalprojection"] as? [String: Any] {
+            if width == nil { width = numericValue(ortho["width"]) }
+            if height == nil { height = numericValue(ortho["height"]) }
+        }
+        guard let width, let height, width > 1, height > 1 else { return nil }
+        return CGSize(width: width, height: height)
+    }
+
+    private static func numericValue(_ value: Any?) -> Double? {
+        if let number = value as? Double { return number }
+        if let number = value as? Int { return Double(number) }
+        if let number = value as? NSNumber { return number.doubleValue }
+        if let text = value as? String { return Double(text) }
+        return nil
     }
 
     /// 定位壁纸目录下的 scene.pkg 并解析其中 scene.json 的 `general` 段。

--- a/Services/StatusBarController.swift
+++ b/Services/StatusBarController.swift
@@ -787,6 +787,10 @@ final class StatusBarController: NSObject {
         guard let payload = sender.representedObject as? CropAspectPayload else { return }
         DisplayCropSettingsStore.shared.update(for: payload.screen) { s in
             s.aspectPreset = payload.preset
+            if payload.preset == .autoFill {
+                s.pan = CGPoint(x: 0.5, y: 0.5)
+                s.zoom = 1.0
+            }
         }
         refreshMenuState()
     }

--- a/Services/WallpaperEngineXBridge.swift
+++ b/Services/WallpaperEngineXBridge.swift
@@ -275,6 +275,8 @@ final class WallpaperEngineXBridge: ObservableObject {
     private var screenWatchdogs: [pid_t: DispatchWorkItem] = [:]
     /// crop 等待 Task（key = screenID），新的 setWallpaper 开始前先 cancel 旧的
     private var cropWaitTasks: [String: Task<Void, Never>] = [:]
+    /// 每屏最近一次读到的 scene canvas 尺寸。热切换会删 canvas-size 文件，新文件没写出前用它重算 crop。
+    private var lastCanvasSizeByScreenID: [String: CGSize] = [:]
     /// 非隔离存储所有活跃 PID，供 deinit 中安全清理
     private nonisolated(unsafe) var _deinitPIDs: Set<pid_t> = []
     /// 启动批次号，防止旧进程的 terminationHandler 污染新进程状态
@@ -854,6 +856,10 @@ final class WallpaperEngineXBridge: ObservableObject {
                 // 否则等待新画布尺寸的任务会把仍可读取的旧文件误判为新场景尺寸，
                 // 在固定比例（如 16:9）下写入错误的 crop。
                 let cropSettings = DisplayCropSettingsStore.shared.settings(for: screen)
+                if let csURL = existingInfo.canvasSizeURL,
+                   let known = readCanvasSize(url: csURL) {
+                    lastCanvasSizeByScreenID[screenID] = known
+                }
                 if let ccURL = existingInfo.cropControlURL {
                     writeCropControl(url: ccURL, crop: nil, viewport: nil)
                 }
@@ -898,18 +904,12 @@ final class WallpaperEngineXBridge: ObservableObject {
                     )
                 }
 
-                // 新壁纸 canvas 尺寸可能不同，等真实尺寸写出后更新 crop
-                // autoFill 模式不需要写 crop-control，Rust 端默认 Cover 即可
+                // 新壁纸 canvas 尺寸可能不同，等真实尺寸写出后更新 crop。
                 if cropSettings.shouldApplyCrop,
-                   let ccURL = existingInfo.cropControlURL,
+                   existingInfo.cropControlURL != nil,
                    let csURL = existingInfo.canvasSizeURL {
-                    let cropSettingsCopy = cropSettings
-                    let cropControlURLCopy = ccURL
                     let canvasSizeURLCopy = csURL
-                    let screenW_c = screenW
-                    let screenH_c = screenH
                     let screenIDCopy = screenID
-                    // 修复：取消上一次同屏的等待 Task，防止快速切换时 Task 叠加
                     cropWaitTasks[screenIDCopy]?.cancel()
                     cropWaitTasks[screenIDCopy] = Task { @MainActor [weak self] in
                         defer { self?.cropWaitTasks.removeValue(forKey: screenIDCopy) }
@@ -920,17 +920,21 @@ final class WallpaperEngineXBridge: ObservableObject {
                             guard let self else { return }
                             guard self.screenProcesses[screenIDCopy]?.pid == existingInfo.pid else { return }
                             if let realSize = self.readCanvasSize(url: canvasSizeURLCopy) {
-                                let layout = CropLayoutEngine.compute(
-                                    wallpaperSize: realSize,
-                                    screenSize: CGSize(width: screenW_c, height: screenH_c),
-                                    settings: cropSettingsCopy)
-                                let vp = layout.viewportRect
-                                let isFullVp = abs(vp.x) < 1e-4 && abs(vp.y) < 1e-4
-                                    && abs(vp.w - 1) < 1e-4 && abs(vp.h - 1) < 1e-4
-                                self.writeCropControl(url: cropControlURLCopy, crop: layout.wallpaperCropRect, viewport: isFullVp ? nil : vp)
+                                self.lastCanvasSizeByScreenID[screenIDCopy] = realSize
+                                if let screen = NSScreen.screens.first(where: {
+                                    $0.wallpaperScreenIdentifier == screenIDCopy
+                                }) {
+                                    self.applyPersistedCrop(for: screen)
+                                }
                                 print("[WallpaperEngineXBridge] 屏幕 \(screenIDCopy) 热切换后 canvas_size 就绪，crop 已重算")
                                 return
                             }
+                        }
+                        print("[WallpaperEngineXBridge] ⚠️ 屏幕 \(screenIDCopy) 热切换等待 canvas_size 超时，用缓存尺寸恢复 crop")
+                        if let screen = NSScreen.screens.first(where: {
+                            $0.wallpaperScreenIdentifier == screenIDCopy
+                        }) {
+                            self.applyPersistedCrop(for: screen)
                         }
                     }
                 }
@@ -1058,14 +1062,9 @@ final class WallpaperEngineXBridge: ObservableObject {
 
                 // 异步等待 canvas_size 就绪后重算 crop
                 if cropSettings.shouldApplyCrop {
-                    let cropSettingsCopy = cropSettings
-                    let cropControlURLCopy = cropControlURL
                     let canvasSizeURLCopy = canvasSizeURL
-                    let screenW_c = screenW
-                    let screenH_c = screenH
                     let genCopy = self.launchGeneration
                     let screenIDCopy = screenID
-                    // 修复：取消上一次同屏的等待 Task，防止快速切换时 Task 叠加
                     cropWaitTasks[screenIDCopy]?.cancel()
                     cropWaitTasks[screenIDCopy] = Task { @MainActor [weak self] in
                         defer { self?.cropWaitTasks.removeValue(forKey: screenIDCopy) }
@@ -1077,19 +1076,23 @@ final class WallpaperEngineXBridge: ObservableObject {
                             guard self.launchGeneration == genCopy,
                                   self.screenProcesses[screenIDCopy]?.generation == genCopy else { return }
                             if let realSize = self.readCanvasSize(url: canvasSizeURLCopy) {
-                                let layout = CropLayoutEngine.compute(
-                                    wallpaperSize: realSize,
-                                    screenSize: CGSize(width: screenW_c, height: screenH_c),
-                                    settings: cropSettingsCopy)
-                                let vp = layout.viewportRect
-                                let isFullVp = abs(vp.x) < 1e-4 && abs(vp.y) < 1e-4
-                                    && abs(vp.w - 1) < 1e-4 && abs(vp.h - 1) < 1e-4
-                                self.writeCropControl(url: cropControlURLCopy, crop: layout.wallpaperCropRect, viewport: isFullVp ? nil : vp)
+                                self.lastCanvasSizeByScreenID[screenIDCopy] = realSize
+                                if let screen = NSScreen.screens.first(where: {
+                                    $0.wallpaperScreenIdentifier == screenIDCopy
+                                }) {
+                                    self.applyPersistedCrop(for: screen)
+                                }
                                 print("[WallpaperEngineXBridge] 屏幕 \(screenIDCopy) canvas_size 就绪 (\(Int(realSize.width))×\(Int(realSize.height)))，crop 已按真实尺寸重算并热更新")
                                 return
                             }
                         }
-                        print("[WallpaperEngineXBridge] ⚠️ 屏幕 \(screenIDCopy) 等待 canvas_size 超时，沿用 fallback crop")
+                        print("[WallpaperEngineXBridge] ⚠️ 屏幕 \(screenIDCopy) 等待 canvas_size 超时，用缓存尺寸恢复 crop")
+                        if let self,
+                           let screen = NSScreen.screens.first(where: {
+                               $0.wallpaperScreenIdentifier == screenIDCopy
+                           }) {
+                            self.applyPersistedCrop(for: screen)
+                        }
                     }
                 }
             } catch {
@@ -1176,6 +1179,9 @@ final class WallpaperEngineXBridge: ObservableObject {
             "screenProcesses": screenProcesses.count,
             "screenRenderStates": screenRenderStates.keys.sorted().joined(separator: ",")
         ])
+        for screen in effectiveScreens {
+            applyPersistedCrop(for: screen)
+        }
         // 清除旧的前台暂停状态，避免 reevaluateCurrentState() 对新启动的渲染器误发 SIGSTOP。
         // 用户之后切走应用时，NSWorkspace app activation 通知会重新施加前台暂停。
         if !preserveAutoPauseState {
@@ -4466,40 +4472,57 @@ final class WallpaperEngineXBridge: ObservableObject {
     /// 两者都支持拖拽期间实时热更新，无需重启渲染器。
     @MainActor
     private func handleCropDidChange(_ note: Notification) {
-        guard isControllingExternalEngine else { return }
         guard !isSettingWallpaper else { return }
         guard let screenID = note.userInfo?["screenID"] as? String,
-              let screen = NSScreen.screens.first(where: { $0.wallpaperScreenIdentifier == screenID }),
-              isManaging(screen: screen) else { return }
+              let screen = NSScreen.screens.first(where: { $0.wallpaperScreenIdentifier == screenID }) else { return }
+        applyPersistedCrop(for: screen)
+    }
+
+    /// 把当前屏已保存的可视区域写回正在跑的 Scene / Web 渲染器。
+    /// 画布尺寸文件被热切换清掉时，用 `lastCanvasSizeByScreenID` 兜底，避免 crop 丢成全图 Cover。
+    @MainActor
+    private func applyPersistedCrop(for screen: NSScreen) {
+        guard isManaging(screen: screen) else { return }
         if isWebWallpaperOn(screen: screen) {
             sendWebCropToWebDaemon(for: screen)
             return
         }
-        // 找到该屏（或同 fingerprint）的运行进程及其 cropControlURL
+        guard isControllingExternalEngine else { return }
+        let screenID = screen.wallpaperScreenIdentifier
         let info = screenProcesses[screenID]
             ?? screenProcesses.values.first(where: { $0.screenID == screenID })
         guard let cropControlURL = info?.cropControlURL else { return }
 
         let cropSettings = DisplayCropSettingsStore.shared.settings(for: screen)
-        // 与 wgpu 窗口一致：canvas 尺寸按全屏窗口计算。
         let f = screen.frame
         let screenW = Int(f.width.rounded())
         let screenH = Int(f.height.rounded())
+        let freshSize = readCanvasSize(url: info?.canvasSizeURL)
+        if let freshSize {
+            lastCanvasSizeByScreenID[screenID] = freshSize
+        }
+        let knownSize = freshSize ?? lastCanvasSizeByScreenID[screenID]
         let nextCrop: UnitRect?
         let nextViewport: UnitRect?
         if cropSettings.shouldApplyCrop {
-            // 读 wgpu 写出的 canvas 尺寸；读不到 fallback 屏尺寸。
-            let wallpaperSize = readCanvasSize(url: info?.canvasSizeURL) ?? CGSize(width: screenW, height: screenH)
-            let layout = CropLayoutEngine.compute(
-                wallpaperSize: wallpaperSize,
-                screenSize: CGSize(width: screenW, height: screenH),
-                settings: cropSettings)
-            nextCrop = layout.wallpaperCropRect
-            // 全屏 viewport 等价于 None
-            let vp = layout.viewportRect
-            let isFullVp = abs(vp.x) < 1e-4 && abs(vp.y) < 1e-4
-                && abs(vp.w - 1) < 1e-4 && abs(vp.h - 1) < 1e-4
-            nextViewport = isFullVp ? nil : vp
+            let wallpaperSize = knownSize ?? CGSize(width: screenW, height: screenH)
+            let isFillWithoutSize = knownSize == nil
+                && (cropSettings.aspectPreset == .autoFill
+                    || (cropSettings.aspectPreset == .custom && cropSettings.customAspect == nil))
+            if isFillWithoutSize {
+                nextCrop = nil
+                nextViewport = nil
+            } else {
+                let layout = CropLayoutEngine.compute(
+                    wallpaperSize: wallpaperSize,
+                    screenSize: CGSize(width: screenW, height: screenH),
+                    settings: cropSettings)
+                nextCrop = layout.wallpaperCropRect
+                let vp = layout.viewportRect
+                let isFullVp = abs(vp.x) < 1e-4 && abs(vp.y) < 1e-4
+                    && abs(vp.w - 1) < 1e-4 && abs(vp.h - 1) < 1e-4
+                nextViewport = isFullVp ? nil : vp
+            }
         } else {
             nextCrop = nil
             nextViewport = nil

--- a/Services/WallpaperEngineXBridge.swift
+++ b/Services/WallpaperEngineXBridge.swift
@@ -275,6 +275,8 @@ final class WallpaperEngineXBridge: ObservableObject {
     private var screenWatchdogs: [pid_t: DispatchWorkItem] = [:]
     /// crop 等待 Task（key = screenID），新的 setWallpaper 开始前先 cancel 旧的
     private var cropWaitTasks: [String: Task<Void, Never>] = [:]
+    /// Scene 路径 → orthogonalprojection 尺寸；nil 表示读过但没有。
+    private var sceneCanvasSizeCache: [String: CGSize?] = [:]
     /// 每屏最近一次读到的 scene canvas 尺寸。热切换会删 canvas-size 文件，新文件没写出前用它重算 crop。
     private var lastCanvasSizeByScreenID: [String: CGSize] = [:]
     /// 非隔离存储所有活跃 PID，供 deinit 中安全清理
@@ -986,13 +988,23 @@ final class WallpaperEngineXBridge: ObservableObject {
             let audioControlURL = createAudioControlURL(screenID: screenID)
             let wallpaperControlURL = createWallpaperControlURL(screenID: screenID)
 
-            // 初始裁切
+            // 初始裁切。优先用画布/视频真实尺寸算居中 cover，避免渲染器默认 Cover 偏一侧。
             let cropSettings = DisplayCropSettingsStore.shared.settings(for: screen)
             let initialLayout: (crop: UnitRect, viewport: UnitRect)? = {
                 guard cropSettings.shouldApplyCrop else { return nil }
-                let wallpaperSize = readCanvasSize(url: canvasSizeURL) ?? CGSize(width: screenW, height: screenH)
+                let wallpaperSize = cropWallpaperSize(
+                    screen: screen,
+                    path: resolvedPath,
+                    canvasSizeURL: canvasSizeURL,
+                    allowCachedCanvas: false
+                )
+                if wallpaperSize == nil,
+                   cropSettings.aspectPreset == .autoFill
+                    || (cropSettings.aspectPreset == .custom && cropSettings.customAspect == nil) {
+                    return nil
+                }
                 let layout = CropLayoutEngine.compute(
-                    wallpaperSize: wallpaperSize,
+                    wallpaperSize: wallpaperSize ?? CGSize(width: screenW, height: screenH),
                     screenSize: CGSize(width: screenW, height: screenH),
                     settings: cropSettings)
                 return (crop: layout.wallpaperCropRect, viewport: layout.viewportRect)
@@ -3407,12 +3419,46 @@ final class WallpaperEngineXBridge: ObservableObject {
         return CGSize(width: w, height: h)
     }
 
-    /// 供 overlay 预览取 wgpu canvas 尺寸（scene 就绪后才有值）。
+    /// 供 overlay 预览取 wgpu canvas 尺寸（scene 就绪后才有值；未就绪时用 scene.json 画布）。
     func canvasSize(for screen: NSScreen) -> CGSize? {
         let screenID = screen.wallpaperScreenIdentifier
         let info = screenProcesses[screenID]
             ?? screenProcesses.values.first(where: { $0.screenID == screenID })
-        return readCanvasSize(url: info?.canvasSizeURL)
+        return cropWallpaperSize(
+            screen: screen,
+            path: renderState(for: screen)?.path,
+            canvasSizeURL: info?.canvasSizeURL,
+            allowCachedCanvas: true
+        )
+    }
+
+    /// 铺满裁切用的壁纸尺寸：真实画布 > scene ortho / Web 内容 > 缓存。
+    private func cropWallpaperSize(
+        screen: NSScreen,
+        path: String?,
+        canvasSizeURL: URL?,
+        allowCachedCanvas: Bool
+    ) -> CGSize? {
+        if let size = readCanvasSize(url: canvasSizeURL) {
+            return size
+        }
+        if let path, let size = sceneCanvasSize(forPath: path) {
+            return size
+        }
+        if let size = webContentSize(for: screen) {
+            return size
+        }
+        if allowCachedCanvas {
+            return lastCanvasSizeByScreenID[screen.wallpaperScreenIdentifier]
+        }
+        return nil
+    }
+
+    private func sceneCanvasSize(forPath path: String) -> CGSize? {
+        if let cached = sceneCanvasSizeCache[path] { return cached }
+        let size = SceneConfigOverrideService.sceneOrthogonalSize(for: path)
+        sceneCanvasSizeCache[path] = size
+        return size
     }
 
     private func writeAudioControl(url: URL, muted: Bool, paused: Bool, volume: Double) {
@@ -4501,7 +4547,12 @@ final class WallpaperEngineXBridge: ObservableObject {
         if let freshSize {
             lastCanvasSizeByScreenID[screenID] = freshSize
         }
-        let knownSize = freshSize ?? lastCanvasSizeByScreenID[screenID]
+        let knownSize = cropWallpaperSize(
+            screen: screen,
+            path: renderState(for: screen)?.path,
+            canvasSizeURL: info?.canvasSizeURL,
+            allowCachedCanvas: true
+        )
         let nextCrop: UnitRect?
         let nextViewport: UnitRect?
         if cropSettings.shouldApplyCrop {

--- a/WallHavenTests/CropLayoutEngineTests.swift
+++ b/WallHavenTests/CropLayoutEngineTests.swift
@@ -117,6 +117,19 @@ final class CropLayoutEngineTests: XCTestCase {
         XCTAssertEqual(layout.wallpaperCropRect.y, 0.1279069767, accuracy: 1e-9)
     }
 
+    /// 默认铺满（不改 pan）在 16:10 屏上居中裁 16:9，左右各切 5%。
+    func testDefaultAutoFillIsCentered() {
+        let layout = CropLayoutEngine.compute(
+            wallpaperSize: CGSize(width: 3840, height: 2160),
+            screenSize: CGSize(width: 1440, height: 900),
+            settings: .defaultSettings)
+        assertRect(layout.viewportRect, 0, 0, 1, 1)
+        XCTAssertEqual(layout.wallpaperCropRect.x, 0.05, accuracy: 1e-6)
+        XCTAssertEqual(layout.wallpaperCropRect.y, 0.0, accuracy: 1e-6)
+        XCTAssertEqual(layout.wallpaperCropRect.w, 0.9, accuracy: 1e-6)
+        XCTAssertEqual(layout.wallpaperCropRect.h, 1.0, accuracy: 1e-6)
+    }
+
     func testAutoFillUsesRealWallpaperOverflowOnDifferentScreenAspect() {
         var s = DisplayCropSettings.defaultSettings
         s.aspectPreset = .autoFill

--- a/WallHavenTests/DisplayCropSettingsStoreTests.swift
+++ b/WallHavenTests/DisplayCropSettingsStoreTests.swift
@@ -14,6 +14,9 @@ final class DisplayCropSettingsStoreTests: XCTestCase {
         let s = store.settings(forScreenID: "nonexistent")
         XCTAssertEqual(s.aspectPreset, .autoFill)
         XCTAssertTrue(s.isEnabled)
+        XCTAssertEqual(s.pan.x, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(s.pan.y, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(s.zoom, 1.0, accuracy: 1e-9)
     }
 
     func testUpdatePersistsForScreenID() {
@@ -29,6 +32,8 @@ final class DisplayCropSettingsStoreTests: XCTestCase {
         let s = store.settings(forScreenID: "screen-B")
         XCTAssertEqual(s.aspectPreset, .autoFill)
         XCTAssertEqual(s.zoom, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(s.pan.x, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(s.pan.y, 0.5, accuracy: 1e-9)
     }
 
     func testClearRemovesEntry() {


### PR DESCRIPTION
## Summary
- 热切换清掉 crop-control / canvas-size 后，用缓存画布尺寸把已保存的可视区域写回，避免裁切丢成默认 Cover。
- 自动（铺满）按 scene/web 真实尺寸写居中 cover；菜单再选铺满时把平移和缩放置中。

基于当前 `jipika/main`，只含这两项，不含 CI 改动。

## Test plan
- [ ] 调好可视区域后换 Scene/Web，裁切应保留
- [ ] 16:9 壁纸铺满 16:10 屏，默认左右对称裁切
- [ ] 菜单选「自动（铺满）」后平移回到中心
- [ ] 重置可视区域后仍是铺满居中


Made with [Cursor](https://cursor.com)