### PR TITLE
fix: 调节可视区域时 ESC 只退出裁切 overlay

### DIFF
--- a/Services/CropAdjustOverlayController.swift
+++ b/Services/CropAdjustOverlayController.swift
@@ -9,13 +9,30 @@ final class CropAdjustOverlayController {
 
     private var windowsByScreenID: [String: NSWindow] = [:]
     private weak var statusItem: NSStatusItem?
+    private var escapeMonitor: Any?
+    /// overlay 已关但同一次 ESC 还在其它 local monitor 里时，仍拦截页面返回。
+    private var eatingEscape = false
 
     private init() {}
 
     // MARK: - Public
 
+    var isAdjusting: Bool { !windowsByScreenID.isEmpty || eatingEscape }
+
     func isActive(for screen: NSScreen) -> Bool {
         windowsByScreenID[screen.wallpaperScreenIdentifier] != nil
+    }
+
+    /// ESC 只关裁切 overlay，不把事件交给详情页/文件夹返回。
+    func dismissIfActive() {
+        guard isAdjusting else { return }
+        eatingEscape = true
+        for screen in NSScreen.screens where windowsByScreenID[screen.wallpaperScreenIdentifier] != nil {
+            exit(for: screen)
+        }
+        DispatchQueue.main.async { [weak self] in
+            self?.eatingEscape = false
+        }
     }
 
     func toggle(for screen: NSScreen, statusBarItemRef: NSStatusItem?) {
@@ -55,6 +72,7 @@ final class CropAdjustOverlayController {
         window.contentView = view
         window.makeKeyAndOrderFront(nil)
         windowsByScreenID[screenID] = window
+        installEscapeMonitorIfNeeded()
     }
 
     private func exit(for screen: NSScreen) {
@@ -64,6 +82,24 @@ final class CropAdjustOverlayController {
         if let window = windowsByScreenID.removeValue(forKey: screenID) {
             window.orderOut(nil)
         }
+        removeEscapeMonitorIfNeeded()
+    }
+
+    private func installEscapeMonitorIfNeeded() {
+        guard escapeMonitor == nil else { return }
+        escapeMonitor = NSEvent.addLocalMonitorForEvents(matching: .keyDown) { event in
+            guard event.keyCode == 53, CropAdjustOverlayController.shared.isAdjusting else {
+                return event
+            }
+            CropAdjustOverlayController.shared.dismissIfActive()
+            return nil
+        }
+    }
+
+    private func removeEscapeMonitorIfNeeded() {
+        guard windowsByScreenID.isEmpty, let escapeMonitor else { return }
+        NSEvent.removeMonitor(escapeMonitor)
+        self.escapeMonitor = nil
     }
 
     /// 按当前屏壁纸类型取真实尺寸，供 overlay 预览 crop 计算。
@@ -96,8 +132,7 @@ private final class CropAdjustOverlayWindow: NSWindow {
 
     override func keyDown(with event: NSEvent) {
         if event.keyCode == 53 { // ESC
-            CropAdjustOverlayController.shared.toggle(
-                for: self.screen ?? NSScreen.main!, statusBarItemRef: nil)
+            CropAdjustOverlayController.shared.dismissIfActive()
             return
         }
         super.keyDown(with: event)

--- a/Views/AnimeDetailSheet.swift
+++ b/Views/AnimeDetailSheet.swift
@@ -201,6 +201,7 @@ struct AnimeDetailSheet: View {
                 }
                 return nil
             case 53: // ESC：返回
+                if CropAdjustOverlayController.shared.isAdjusting { return event }
                 self.isPresented = false
                 return nil
             default:

--- a/Views/MangaDetailSheet.swift
+++ b/Views/MangaDetailSheet.swift
@@ -252,6 +252,7 @@ struct MangaDetailSheet: View {
                 viewModel.nextPage()
                 return nil
             case 53:  // esc
+                if CropAdjustOverlayController.shared.isAdjusting { return event }
                 dismiss()
                 return nil
             default:

--- a/Views/MediaDetailSheet.swift
+++ b/Views/MediaDetailSheet.swift
@@ -2940,6 +2940,7 @@ struct MediaDetailSheet: View {
                 self.navigateToNextMedia()
                 return nil
             case 53: // ESC：优先关闭当前弹窗，再关闭预览，最后返回详情栈
+                if CropAdjustOverlayController.shared.isAdjusting { return event }
                 if self.showSceneBakeRendererDialog {
                     self.dismissSceneBakeRendererDialog()
                 } else if self.showAuthorSheet {

--- a/Views/MyLibraryContentView.swift
+++ b/Views/MyLibraryContentView.swift
@@ -1007,6 +1007,7 @@ struct MyLibraryContentView: View {
                   event.window?.isKeyWindow == true,
                   event.keyCode == 53,
                   event.modifierFlags.intersection([.command, .control, .option]).isEmpty,
+                  !CropAdjustOverlayController.shared.isAdjusting,
                   !self.isPresentingLibraryModal else {
                 return event
             }

--- a/Views/WallpaperDetailSheet.swift
+++ b/Views/WallpaperDetailSheet.swift
@@ -1596,6 +1596,7 @@ struct WallpaperDetailSheet: View {
                 self.navigateToNextWallpaper()
                 return nil
             case 53: // ESC：优先关闭当前弹窗，再关闭预览，最后返回详情栈
+                if CropAdjustOverlayController.shared.isAdjusting { return event }
                 if self.showAuthorSheet {
                     self.dismissAuthorSheet()
                 } else if PreviewWindowManager.shared.isPresented {


### PR DESCRIPTION
## Summary
- 裁切 overlay 打开时，ESC 会先被详情页/文件夹的键盘监听吃掉，导致先退出 WaifuX 页面层级
- 在 `CropAdjustOverlayController` 增加 local monitor，裁切进行中优先吞掉 ESC 并只关闭 overlay
- 详情页与媒体库文件夹返回的 ESC 处理在裁切进行中不再响应

## Test plan
- [ ] 打开壁纸详情，进入「调节可视区域」，按 ESC → 只退出裁切，仍停留在详情页
- [ ] 在媒体库文件夹内调节可视区域，按 ESC → 只退出裁切，不返回上一级文件夹
- [ ] 未开启裁切调节时，ESC 仍正常关闭详情/返回文件夹


Made with [Cursor](https://cursor.com)