### PR TITLE
优化首页沉浸式交互与壁纸详情对比度，限制图片预取并发

### DIFF
--- a/App/WaifuXApp.swift
+++ b/App/WaifuXApp.swift
@@ -173,6 +173,12 @@ final class EdgeToEdgeHostingView<Content: View>: NSHostingView<Content> {
         ])
     }
 
+    // Let the first click both activate an inactive window and reach SwiftUI
+    // controls. This matches standard macOS control behavior for the main UI.
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
     @available(*, unavailable)
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")

--- a/App/WaifuXApp.swift
+++ b/App/WaifuXApp.swift
@@ -249,7 +249,9 @@ struct WaifuXApp {
         // 下载配置
         let downloader = KingfisherManager.shared.downloader
         let configuration = downloader.sessionConfiguration
-        configuration.httpMaximumConnectionsPerHost = 10
+        // 探索页的可见 cell、图片预取和分页请求共享该下载器；限制并发，
+        // 避免快速滚动时大量请求同时占用连接和解码内存。
+        configuration.httpMaximumConnectionsPerHost = 6
         configuration.waitsForConnectivity = true
         configuration.timeoutIntervalForRequest = 60
         configuration.timeoutIntervalForResource = 180

--- a/Components/TopNavigationBar.swift
+++ b/Components/TopNavigationBar.swift
@@ -241,13 +241,18 @@ private struct TopBarCircleButton: View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.88))
+                .foregroundStyle(.white.opacity(isHovered ? 1.0 : 0.88))
                 .frame(width: size, height: size)
                 .contentShape(Circle())
-                .detailGlassCircleChrome()
+                .background { Circle().fill(topBarBaseColor(isHovered: isHovered)) }
+                .detailGlassCircleChrome(
+                    tint: Color.white.opacity(isHovered ? 0.16 : 0.09),
+                    level: .max
+                )
         }
         .buttonStyle(.plain)
         .contentShape(Rectangle())
+        .scaleEffect(isHovered ? 1.04 : 1.0)
         .preferredColorScheme(.dark)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.16)) {
@@ -274,9 +279,14 @@ struct GuessYouLikeNavButton: View {
             .foregroundStyle(.white.opacity(isHovered ? 0.96 : 0.82))
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
-            .detailGlassCapsuleChrome()
+            .background { Capsule().fill(topBarBaseColor(isHovered: isHovered)) }
+            .detailGlassCapsuleChrome(
+                tint: Color.white.opacity(isHovered ? 0.16 : 0.09),
+                level: .max
+            )
         }
         .buttonStyle(.plain)
+        .scaleEffect(isHovered ? 1.025 : 1.0)
         .preferredColorScheme(.dark)
         .onHover { hovering in
             withAnimation(.easeInOut(duration: 0.16)) {
@@ -284,6 +294,14 @@ struct GuessYouLikeNavButton: View {
             }
         }
     }
+}
+
+private func topBarBaseColor(isHovered: Bool) -> Color {
+    Color(
+        red: isHovered ? 0.34 : 0.25,
+        green: isHovered ? 0.34 : 0.25,
+        blue: isHovered ? 0.34 : 0.25
+    )
 }
 
 // MARK: - 帮助/操作手册弹窗

--- a/Components/TopNavigationBar.swift
+++ b/Components/TopNavigationBar.swift
@@ -44,6 +44,7 @@ public enum MainTab: String, CaseIterable {
 // MARK: - 顶部导航栏组件
 struct TopNavigationBar: View {
     @Binding var selectedTab: MainTab
+    var isChromeHidden: Bool = false
     let onOpenSettings: () -> Void
     let onGuessYouLike: () -> Void
     let onClose: () -> Void
@@ -88,6 +89,8 @@ struct TopNavigationBar: View {
                         onOpenSettings()
                     }
                 }
+                .opacity(isChromeHidden ? 0 : 1)
+                .allowsHitTesting(!isChromeHidden)
             }
 
             // 顶层：Tabs 绝对居中于整个顶栏宽度
@@ -97,6 +100,8 @@ struct TopNavigationBar: View {
                 controlHeight: controlHeight
             )
             .frame(height: controlHeight, alignment: .center)
+            .opacity(isChromeHidden ? 0 : 1)
+            .allowsHitTesting(!isChromeHidden)
         }
         .padding(.leading, 12)
         .padding(.trailing, 12)

--- a/Services/SystemMemoryPressure.swift
+++ b/Services/SystemMemoryPressure.swift
@@ -19,6 +19,12 @@ final class ForegroundPrefetchManager {
     ) -> UUID? {
         guard !urls.isEmpty else { return nil }
 
+        // 同一前台场景只保留一组预取，避免连续刷新/分页时累积多个
+        // ImagePrefetcher，并与可见 cell 的请求争抢连接和内存。
+        if let namespace {
+            stop(namespace: namespace)
+        }
+
         let token = UUID()
         let prefetcher = ImagePrefetcher(
             urls: urls,

--- a/Services/WallpaperEngineXBridge.swift
+++ b/Services/WallpaperEngineXBridge.swift
@@ -948,7 +948,7 @@ final class WallpaperEngineXBridge: ObservableObject {
                         if let screen = NSScreen.screens.first(where: {
                             $0.wallpaperScreenIdentifier == screenIDCopy
                         }) {
-                            self.applyPersistedCrop(for: screen)
+                            self?.applyPersistedCrop(for: screen)
                         }
                     }
                 }

--- a/ViewModels/WallpaperViewModel.swift
+++ b/ViewModels/WallpaperViewModel.swift
@@ -919,8 +919,8 @@ class WallpaperViewModel: ObservableObject {
                 if results.data.isEmpty {
                     errorMessage = t("explore.noResults")
                 } else {
-                    // 预加载前几张图片
-                    preloadImages(for: Array(results.data.prefix(4)))
+                    // 只预取极少量首屏图片；可见 cell 自身负责其余图片的懒加载。
+                    preloadImages(for: Array(results.data.prefix(2)))
                 }
             } catch is CancellationError {
                 isLoading = false
@@ -1065,6 +1065,11 @@ class WallpaperViewModel: ObservableObject {
                 let nextPage = currentPage + 1
                 let results: WallpaperSearchResponse
 
+                // 先等待正在进行的下一页预取。否则预取尚未完成时触底会再次请求同一页。
+                if let preloadTask {
+                    await preloadTask.value
+                }
+
                 // 检查是否有预加载的数据
                 if let cached = preloadedResponse,
                    cached.meta.currentPage == nextPage,
@@ -1107,8 +1112,8 @@ class WallpaperViewModel: ObservableObject {
                 currentPage = nextPage
                 hasMorePages = currentPage < results.meta.lastPage
 
-                // 预加载新加载的图片
-                preloadImages(for: Array(appended.prefix(2)))
+                // 只预取一张后续图片，其余由可见 cell 按需加载。
+                preloadImages(for: Array(appended.prefix(1)))
 
                 // 预加载下一页数据
                 if hasMorePages {
@@ -1206,7 +1211,8 @@ class WallpaperViewModel: ObservableObject {
 
     // MARK: - 图片预加载
     func preloadImages(for wallpapers: [Wallpaper]) {
-        let urls = wallpapers.compactMap(\.gridPreviewURL)
+        // 预取只服务于紧邻视口的少量项目；完整列表由 NSCollectionView 的可见 cell 懒加载。
+        let urls = Array(wallpapers.compactMap(\.gridPreviewURL).prefix(2))
         let targetSize = CGSize(width: 512, height: 512)
         ForegroundPrefetchManager.shared.start(
             urls: urls,

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -177,6 +177,8 @@ private struct HomeTabPage: View {
             mediaViewModel: mediaViewModel,
             selectedWallpaper: navigationState.binding(for: \.selectedWallpaper),
             selectedMedia: navigationState.binding(for: \.selectedMedia),
+            onOpenWallpapers: { navigationState.selectedTab = .wallpaperExplore },
+            onOpenMedia: { navigationState.selectedTab = .mediaExplore },
             isTabActive: navigationState.selectedTab == .home
         )
         .environment(\.coverGIFPlaybackHostActive, navigationState.selectedTab == .home)

--- a/Views/ContentView.swift
+++ b/Views/ContentView.swift
@@ -22,6 +22,7 @@ private struct EdgeToEdgeContainer<Content: View>: View {
 @MainActor
 private final class MainContentNavigationState: ObservableObject {
     @Published var selectedTab: MainTab = .home
+    @Published var isHomeChromeHidden = false
     @Published var selectedWallpaper: Wallpaper?
     @Published var selectedMedia: MediaItem?
     @Published var selectedAnime: AnimeSearchResult?
@@ -31,6 +32,9 @@ private final class MainContentNavigationState: ObservableObject {
     @Published var libraryWallpaperContext: [Wallpaper] = []
     @Published var libraryMediaContext: [MediaItem] = []
 
+    private var mouseMovementMonitor: Any?
+    private var mouseRevealOrigin: NSPoint?
+
     func binding<Value>(for keyPath: ReferenceWritableKeyPath<MainContentNavigationState, Value>) -> Binding<Value> {
         Binding(
             get: { self[keyPath: keyPath] },
@@ -39,6 +43,8 @@ private final class MainContentNavigationState: ObservableObject {
     }
 
     func resetForMemoryRelease() {
+        isHomeChromeHidden = false
+        mouseRevealOrigin = nil
         selectedWallpaper = nil
         selectedMedia = nil
         selectedAnime = nil
@@ -48,6 +54,36 @@ private final class MainContentNavigationState: ObservableObject {
         libraryWallpaperContext.removeAll()
         libraryMediaContext.removeAll()
         selectedTab = .home
+    }
+
+    func startMouseMovementMonitoring() {
+        guard mouseMovementMonitor == nil else { return }
+        mouseMovementMonitor = NSEvent.addLocalMonitorForEvents(matching: .mouseMoved) { [weak self] event in
+            let location = event.locationInWindow
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                guard self.isHomeChromeHidden else {
+                    self.mouseRevealOrigin = nil
+                    return
+                }
+                guard let origin = self.mouseRevealOrigin else {
+                    self.mouseRevealOrigin = location
+                    return
+                }
+                let dx = location.x - origin.x
+                let dy = location.y - origin.y
+                guard (dx * dx + dy * dy) >= 576 else { return }
+                self.isHomeChromeHidden = false
+                self.mouseRevealOrigin = nil
+            }
+            return event
+        }
+    }
+
+    func stopMouseMovementMonitoring() {
+        guard let mouseMovementMonitor else { return }
+        NSEvent.removeMonitor(mouseMovementMonitor)
+        self.mouseMovementMonitor = nil
     }
 }
 
@@ -177,6 +213,7 @@ private struct HomeTabPage: View {
             mediaViewModel: mediaViewModel,
             selectedWallpaper: navigationState.binding(for: \.selectedWallpaper),
             selectedMedia: navigationState.binding(for: \.selectedMedia),
+            isHomeChromeHidden: navigationState.binding(for: \.isHomeChromeHidden),
             onOpenWallpapers: { navigationState.selectedTab = .wallpaperExplore },
             onOpenMedia: { navigationState.selectedTab = .mediaExplore },
             isTabActive: navigationState.selectedTab == .home
@@ -305,13 +342,16 @@ struct ContentView: View {
             AppResponsivenessMonitor.noteDetailDepth(detailPath.count)
             AppResponsivenessMonitor.noteScenePhase("contentViewVisible")
             registerDetailBackSwipeHandler()
+            navigationState.startMouseMovementMonitoring()
             consumePendingWallpaperDetailRequest()
         }
         .onDisappear {
             unregisterDetailBackSwipeHandler()
+            navigationState.stopMouseMovementMonitoring()
         }
         .onChange(of: navigationState.selectedTab) { _, tab in
             AppResponsivenessMonitor.noteTabChange(tab.title)
+            navigationState.isHomeChromeHidden = false
         }
         .onChange(of: detailPath.count) { _, depth in
             AppResponsivenessMonitor.noteDetailDepth(depth)
@@ -464,6 +504,7 @@ struct ContentView: View {
             .environment(\.mainTopBarContentPadding, MainTopBarLayout.legacyContentTopPadding)
             .overlay(alignment: .top) {
                 topNavigationBar
+                    .animation(.easeOut(duration: 0.18), value: navigationState.isHomeChromeHidden)
             }
     }
 
@@ -499,6 +540,7 @@ struct ContentView: View {
     private var topNavigationBar: some View {
         TopNavigationBar(
             selectedTab: navigationState.binding(for: \.selectedTab),
+            isChromeHidden: navigationState.selectedTab == .home && navigationState.isHomeChromeHidden,
             onOpenSettings: { openSettingsWindow() },
             onGuessYouLike: { guessYouLikeVM.show() },
             onClose: { hideMainWindow() },

--- a/Views/HomeContentView.swift
+++ b/Views/HomeContentView.swift
@@ -120,6 +120,7 @@ struct HomeContentView: View {
     @ObservedObject var mediaViewModel: MediaExploreViewModel
     @Binding var selectedWallpaper: Wallpaper?
     @Binding var selectedMedia: MediaItem?
+    @Binding var isHomeChromeHidden: Bool
     let onOpenWallpapers: () -> Void
     let onOpenMedia: () -> Void
     /// 为 false 时不挂载重 UI（非当前 Tab），避免五 Tab 同时跑 ScrollView/轮播
@@ -417,6 +418,9 @@ struct HomeContentView: View {
         .frame(width: width, height: height, alignment: .leading)
         .clipped()
         .contentShape(Rectangle())
+        .onTapGesture {
+            isHomeChromeHidden.toggle()
+        }
         .simultaneousGesture(
             heroCarouselDragGesture(width: width)
         )

--- a/Views/HomeContentView.swift
+++ b/Views/HomeContentView.swift
@@ -120,6 +120,8 @@ struct HomeContentView: View {
     @ObservedObject var mediaViewModel: MediaExploreViewModel
     @Binding var selectedWallpaper: Wallpaper?
     @Binding var selectedMedia: MediaItem?
+    let onOpenWallpapers: () -> Void
+    let onOpenMedia: () -> Void
     /// 为 false 时不挂载重 UI（非当前 Tab），避免五 Tab 同时跑 ScrollView/轮播
     var isTabActive: Bool = true
     @ObservedObject private var arcSettings = ArcBackgroundSettings.shared
@@ -433,7 +435,8 @@ struct HomeContentView: View {
                     atmosphereSecondary: atmosphereController.secondary,
                     onSelect: { wallpaper in
                         selectedWallpaper = wallpaper
-                    }
+                    },
+                    onSeeAll: onOpenWallpapers
                 )
             }
 
@@ -447,7 +450,8 @@ struct HomeContentView: View {
                     atmosphereSecondary: atmosphereController.secondary,
                     onSelect: { item in
                         selectedMedia = item
-                    }
+                    },
+                    onSeeAll: onOpenMedia
                 )
             }
         }
@@ -1198,6 +1202,8 @@ private struct HomeShelfSection: View {
     let atmospherePrimary: Color
     let atmosphereSecondary: Color
     let onSelect: (Wallpaper) -> Void
+    let onSeeAll: () -> Void
+    @State private var isSeeAllHovered = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -1206,14 +1212,10 @@ private struct HomeShelfSection: View {
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(.white)
 
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(.white.opacity(0.54))
-                    .frame(width: 22, height: 22)
-                    .background(
-                        Circle()
-                            .fill(Color.white.opacity(0.06))
-                    )
+                HomeSectionSeeAllButton(
+                    isHovered: $isSeeAllHovered,
+                    action: onSeeAll
+                )
 
                 Spacer()
             }
@@ -1506,6 +1508,8 @@ private struct HomeMediaSection: View {
     let atmospherePrimary: Color
     let atmosphereSecondary: Color
     let onSelect: (MediaItem) -> Void
+    let onSeeAll: () -> Void
+    @State private var isSeeAllHovered = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 18) {
@@ -1514,14 +1518,10 @@ private struct HomeMediaSection: View {
                     .font(.system(size: 18, weight: .bold))
                     .foregroundStyle(.white)
 
-                Image(systemName: "chevron.right")
-                    .font(.system(size: 11, weight: .bold))
-                    .foregroundStyle(.white.opacity(0.54))
-                    .frame(width: 22, height: 22)
-                    .background(
-                        Circle()
-                            .fill(Color.white.opacity(0.06))
-                    )
+                HomeSectionSeeAllButton(
+                    isHovered: $isSeeAllHovered,
+                    action: onSeeAll
+                )
 
                 Spacer()
             }
@@ -1557,6 +1557,39 @@ private struct HomeMediaSection: View {
                 .frame(height: 158)
             }
         }
+    }
+}
+
+/// Stable hit target for the small trailing button used by home shelves.
+/// The hit shape lives inside the Button label so it remains reliable in a ScrollView.
+private struct HomeSectionSeeAllButton: View {
+    @Binding var isHovered: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            ZStack {
+                Circle()
+                    .liquidGlassSurface(
+                        .regular,
+                        tint: Color.white.opacity(isHovered ? 0.12 : 0.04),
+                        in: Circle(),
+                        lightweight: true
+                    )
+
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(isHovered ? .white : .white.opacity(0.54))
+            }
+            .frame(width: 22, height: 22)
+            // Keep the larger hit target while keeping the visual control compact.
+            .frame(width: 36, height: 36)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .onHover { isHovered = $0 }
+        .help(t("view.all"))
+        .accessibilityLabel(Text(t("view.all")))
     }
 }
 

--- a/Views/WallpaperDetailSheet.swift
+++ b/Views/WallpaperDetailSheet.swift
@@ -18,6 +18,26 @@ struct WallpaperDetailSheet: View {
     @State private var isSettingWallpaper = false
     @State private var isVisible = false
     @State private var isImageLoaded = false
+
+    private var usesDarkHeroForeground: Bool {
+        let luminances = wallpaper.colors.compactMap(Self.relativeLuminance(from:))
+        // Unknown/local images default to dark controls because the hero area is
+        // otherwise most likely to lose contrast against a light preview.
+        guard !luminances.isEmpty else { return true }
+        return luminances.reduce(0, +) / Double(luminances.count) > 0.58
+    }
+
+    private var heroForeground: Color {
+        usesDarkHeroForeground ? Color(hex: "17171B") : .white
+    }
+
+    private var heroSecondaryForeground: Color {
+        heroForeground.opacity(usesDarkHeroForeground ? 0.62 : 0.60)
+    }
+
+    private var heroGlassTint: Color? {
+        usesDarkHeroForeground ? Color.white.opacity(0.34) : nil
+    }
     @State private var scrollOffset: CGFloat = 0
     @State private var showInfoBubble = false
     @State private var isHeroContentHidden = false
@@ -87,6 +107,16 @@ struct WallpaperDetailSheet: View {
 
     private var isDownloading: Bool {
         downloadActivity.isDownloading(itemID: wallpaper.id)
+    }
+
+    private static func relativeLuminance(from rawHex: String) -> Double? {
+        var hex = rawHex.trimmingCharacters(in: CharacterSet(charactersIn: "# "))
+        if hex.count == 8 { hex = String(hex.dropFirst(2)) }
+        guard hex.count == 6, let value = UInt64(hex, radix: 16) else { return nil }
+        let r = Double((value >> 16) & 0xFF) / 255
+        let g = Double((value >> 8) & 0xFF) / 255
+        let b = Double(value & 0xFF) / 255
+        return 0.2126 * r + 0.7152 * g + 0.0722 * b
     }
 
     var body: some View {
@@ -606,6 +636,7 @@ struct WallpaperDetailSheet: View {
                     .lineLimit(2)
                     .minimumScaleFactor(0.72)
                     .detailGlassTitleChrome()
+                    .foregroundStyle(heroForeground)
 
                 detailCategoryBadge
 
@@ -647,6 +678,23 @@ struct WallpaperDetailSheet: View {
         }
         .frame(maxWidth: 920)
         .frame(maxWidth: .infinity)
+        .background {
+            // Keep the wallpaper visible while giving glass controls a stable
+            // contrast field when the artwork is bright in the center.
+            RadialGradient(
+                colors: [
+                    Color.black.opacity(usesDarkHeroForeground ? 0.10 : 0.06),
+                    Color.black.opacity(usesDarkHeroForeground ? 0.03 : 0.01),
+                    .clear
+                ],
+                center: .center,
+                startRadius: 40,
+                endRadius: 560
+            )
+            .frame(height: 430)
+            .blur(radius: 18)
+            .allowsHitTesting(false)
+        }
     }
 
     // MARK: - 按钮行（带左右横线）
@@ -662,9 +710,9 @@ struct WallpaperDetailSheet: View {
                 } label: {
                     DetailSheetCircleIconLabel(
                         systemName: viewModel.isFavorite(wallpaper) ? "heart.fill" : "heart",
-                        foreground: viewModel.isFavorite(wallpaper) ? Color(hex: "FF5A7D") : .white
+                        foreground: viewModel.isFavorite(wallpaper) ? Color(hex: "FF5A7D") : heroForeground
                     )
-                    .detailGlassCircleChrome()
+                    .detailGlassCircleChrome(tint: heroGlassTint)
                 }
                 .buttonStyle(.plain)
 
@@ -672,8 +720,11 @@ struct WallpaperDetailSheet: View {
                     Button {
                         previewWallpaper()
                     } label: {
-                        DetailSheetCircleIconLabel(systemName: "arrow.up.backward.and.arrow.down.forward")
-                            .detailGlassCircleChrome()
+                        DetailSheetCircleIconLabel(
+                            systemName: "arrow.up.backward.and.arrow.down.forward",
+                            foreground: heroForeground
+                        )
+                            .detailGlassCircleChrome(tint: heroGlassTint)
                     }
                     .buttonStyle(.plain)
                     .help(t("preview"))
@@ -697,11 +748,11 @@ struct WallpaperDetailSheet: View {
                             .fixedSize(horizontal: true, vertical: false)
                     }
                 }
-                .foregroundStyle(.white)
+                .foregroundStyle(heroForeground)
                 .padding(.horizontal, 28)
                 .frame(height: 46)
                 .contentShape(Capsule())
-                .detailPrimaryGlassButtonChrome()
+                .detailPrimaryGlassButtonChrome(tint: heroGlassTint)
             }
             .buttonStyle(.plain)
             .disabled(isSettingWallpaper)
@@ -713,8 +764,11 @@ struct WallpaperDetailSheet: View {
                         downloadWallpaper()
                     }
                 } label: {
-                    DetailSheetCircleIconLabel(systemName: isAlreadyDownloaded ? "checkmark" : "arrow.down")
-                        .detailGlassCircleChrome()
+                    DetailSheetCircleIconLabel(
+                        systemName: isAlreadyDownloaded ? "checkmark" : "arrow.down",
+                        foreground: heroForeground
+                    )
+                        .detailGlassCircleChrome(tint: heroGlassTint)
                 }
                 .buttonStyle(.plain)
                 .disabled(isDownloading || isAlreadyDownloaded)
@@ -722,8 +776,8 @@ struct WallpaperDetailSheet: View {
                 Button {
                     showMoreOptionsPopover = true
                 } label: {
-                    DetailSheetCircleIconLabel(systemName: "ellipsis")
-                        .detailGlassCircleChrome()
+                    DetailSheetCircleIconLabel(systemName: "ellipsis", foreground: heroForeground)
+                        .detailGlassCircleChrome(tint: heroGlassTint)
                 }
                 .buttonStyle(.plain)
                 .help(t("wallpaperDetail.moreOptions"))
@@ -1181,11 +1235,11 @@ struct WallpaperDetailSheet: View {
     private var detailCategoryBadge: some View {
         Text("\(wallpaper.categoryDisplayName) · \(wallpaper.purityDisplayName)")
             .font(.system(size: 13, weight: .bold))
-            .foregroundStyle(.white.opacity(0.85))
+            .foregroundStyle(heroForeground.opacity(0.85))
             .tracking(2)
             .padding(.horizontal, 16)
             .frame(height: 34)
-            .detailGlassCapsuleChrome(level: .prominent)
+            .detailGlassCapsuleChrome(tint: heroGlassTint, level: .prominent)
     }
 
     // MARK: - 元数据胶囊（参考图风格：细长边框）
@@ -1193,17 +1247,17 @@ struct WallpaperDetailSheet: View {
         HStack(spacing: 4) {
             Text(label)
                 .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(.white.opacity(0.6))
+                .foregroundStyle(heroSecondaryForeground)
             Text(value)
                 .font(.system(size: 12, weight: .semibold))
-                .foregroundStyle(.white.opacity(0.9))
+                .foregroundStyle(heroForeground.opacity(0.9))
             if isInteractive {
                 detailDisclosureIndicator
             }
         }
         .padding(.horizontal, 14)
         .frame(height: 32)
-        .detailGlassCapsuleChrome(level: .prominent)
+        .detailGlassCapsuleChrome(tint: heroGlassTint, level: .prominent)
         .padding(.trailing, isLast ? 0 : 8)
     }
 
@@ -1243,7 +1297,7 @@ struct WallpaperDetailSheet: View {
     private var detailDisclosureIndicator: some View {
         Image(systemName: "chevron.right")
             .font(.system(size: 9, weight: .bold))
-            .foregroundStyle(.white.opacity(0.32))
+            .foregroundStyle(heroForeground.opacity(0.32))
     }
 
     // MARK: - 壁纸详情 API 获取（补充 uploader 数据）


### PR DESCRIPTION
## 背景

优化首页与壁纸详情页的视觉表现和交互体验，同时降低快速滚动、分页加载时图片请求过多带来的连接和内存压力。

## 主要变更

- 优化首页海报沉浸式交互
  - 点击首页海报主体可隐藏或恢复顶部标签及操作栏。
  - 保留窗口红绿灯按钮显示。
  - 隐藏状态下移动鼠标达到一定距离后自动恢复顶部内容。
  - 切换 Tab 或释放内存时自动重置隐藏状态。
- 修复首页“查看全部”按钮交互
  - 修复窗口未激活时首次点击无法触发的问题。
  - 扩大按钮命中区域，提升在横向滚动容器中的点击可靠性。
  - 增加悬停状态、玻璃质感和辅助功能标签。
  - 支持直接跳转到对应的壁纸或媒体探索页。
- 优化顶部导航栏玻璃控件
  - 调整按钮背景、透明度和悬停反馈。
  - 增强按钮在不同背景下的可见性和交互反馈。
- 提升壁纸详情页对比度
  - 根据壁纸主色亮度动态选择深色或浅色前景内容。
  - 调整标题、分类标签、元数据和操作按钮的颜色。
  - 在明亮壁纸上增加轻量遮罩，确保控件和文字清晰可读。
- 限制图片预取并发
  - 将图片下载器的单主机并发连接数从 10 调整为 6。
  - 减少首屏及后续分页的预取数量。
  - 同一场景启动新的预取任务时取消旧任务。
  - 等待下一页预取完成后再触发加载，避免重复请求。

## 预期效果

- 首页海报浏览更加沉浸，顶部控件显示与隐藏更自然。
- 首页“查看全部”按钮首次点击和滚动场景下更加稳定。
- 壁纸详情页在亮色和暗色壁纸上都能保持良好的文字与控件对比度。
- 快速滚动和连续分页时减少并发请求、重复加载及图片解码造成的内存压力。